### PR TITLE
Resize virtual machine disk image from SDK details

### DIFF
--- a/src/plugins/mer/meroptionswidget.cpp
+++ b/src/plugins/mer/meroptionswidget.cpp
@@ -329,40 +329,29 @@ void MerOptionsWidget::onResizeDiskImageButtonClicked(const QString &uuid, int c
 
 bool MerOptionsWidget::showCloseVirtualMachineDialog(const QString &informativeText)
 {
-    QPointer<QMessageBox> questionBox =
-        new QMessageBox(QMessageBox::Question,
-                        tr("Close Virtual Machine"),
-                        tr("Close the \"%1\" virtual machine?").arg(m_virtualMachine),
-                        QMessageBox::Yes | QMessageBox::No,
-                        this);
+    QMessageBox questionBox(QMessageBox::Question,
+                            tr("Close Virtual Machine"),
+                            tr("Close the \"%1\" virtual machine?").arg(m_virtualMachine),
+                            QMessageBox::Yes | QMessageBox::No);
 
-    questionBox->setInformativeText(informativeText);
-    questionBox->setDefaultButton(QMessageBox::No);
+    questionBox.setInformativeText(informativeText);
+    questionBox.setDefaultButton(QMessageBox::No);
 
-    const int response = questionBox->exec();
-
-    delete questionBox;
-
-    return (response == QMessageBox::Yes);
+    return (questionBox.exec() == QMessageBox::Yes);
 }
 
 bool MerOptionsWidget::showStartVirtualMachineDialog(const QString &informativeText)
 {
-    QPointer<QMessageBox> questionBox =
-        new QMessageBox(QMessageBox::Question,
-                        tr("Start Virtual Machine"),
-                        tr("Start the \"%1\" virtual machine?").arg(m_virtualMachine),
-                        QMessageBox::Yes | QMessageBox::No,
-                        this);
+    QMessageBox questionBox(QMessageBox::Question,
+                            tr("Start Virtual Machine"),
+                            tr("Start the \"%1\" virtual machine?").arg(m_virtualMachine),
+                            QMessageBox::Yes | QMessageBox::No,
+                            this);
 
-    questionBox->setInformativeText(informativeText);
-    questionBox->setDefaultButton(QMessageBox::Yes);
+    questionBox.setInformativeText(informativeText);
+    questionBox.setDefaultButton(QMessageBox::Yes);
 
-    const int response = questionBox->exec();
-
-    delete questionBox;
-
-    return (response == QMessageBox::Yes);
+    return (questionBox.exec() == QMessageBox::Yes);
 }
 
 void MerOptionsWidget::update()

--- a/src/plugins/mer/meroptionswidget.h
+++ b/src/plugins/mer/meroptionswidget.h
@@ -68,7 +68,7 @@ private slots:
     void onSshTimeoutChanged(int timeout);
     void onHeadlessCheckBoxToggled(bool checked);
     void onSrcFolderApplyButtonClicked(const QString &path);
-    void onResizeDiskImageButtonClicked(const QString &uuid, int capacity, int newCapacity);
+    void onResizeDiskImageButtonClicked(const QString &uuid, int capacity);
     void update();
 
 private:

--- a/src/plugins/mer/meroptionswidget.h
+++ b/src/plugins/mer/meroptionswidget.h
@@ -68,7 +68,12 @@ private slots:
     void onSshTimeoutChanged(int timeout);
     void onHeadlessCheckBoxToggled(bool checked);
     void onSrcFolderApplyButtonClicked(const QString &path);
+    void onResizeDiskImageButtonClicked(const QString &uuid, int capacity, int newCapacity);
     void update();
+
+private:
+    bool showCloseVirtualMachineDialog(const QString &informativeText);
+    bool showStartVirtualMachineDialog(const QString &informativeText);
 
 private:
     Ui::MerOptionsWidget *m_ui;

--- a/src/plugins/mer/mersdkdetailswidget.cpp
+++ b/src/plugins/mer/mersdkdetailswidget.cpp
@@ -49,6 +49,7 @@ MerSdkDetailsWidget::MerSdkDetailsWidget(QWidget *parent)
     connect(m_ui->sshTimeoutSpinBox, SIGNAL(valueChanged(int)), SIGNAL(sshTimeoutChanged(int)));
     connect(m_ui->headlessCheckBox, SIGNAL(toggled(bool)), SIGNAL(headlessCheckBoxToggled(bool)));
     connect(m_ui->srcFolderApplyButton, SIGNAL(clicked()), SLOT(onSrcFolderApplyButtonClicked()));
+    connect(m_ui->diskImageCapacitySpinBox, SIGNAL(valueChanged(int)), SLOT(onDiskImageCapacityChanged(int)));
     connect(m_ui->resizeDiskImageButton, SIGNAL(clicked()), SLOT(onResizeDiskImageButtonClicked()));
 
     m_ui->privateKeyPathChooser->setExpectedKind(Utils::PathChooser::File);
@@ -100,7 +101,12 @@ void MerSdkDetailsWidget::resetDiskImageCapacity()
     m_ui->diskImageCapacitySpinBox->setMinimum(m_diskImageCapacity);
     m_ui->diskImageCapacitySpinBox->setValue(m_diskImageCapacity);
     m_ui->diskImageCapacitySpinBox->setEnabled(resizingEnabled);
-    m_ui->resizeDiskImageButton->setEnabled(resizingEnabled);
+    m_ui->resizeDiskImageButton->setEnabled(false);
+}
+
+void MerSdkDetailsWidget::setResizeButtonEnabled(bool enabled)
+{
+    m_ui->resizeDiskImageButton->setEnabled(enabled);
 }
 
 void MerSdkDetailsWidget::setSdk(const MerSdk *sdk)
@@ -185,11 +191,14 @@ void MerSdkDetailsWidget::onSrcFolderApplyButtonClicked()
     }
 }
 
+void MerSdkDetailsWidget::onDiskImageCapacityChanged(int capacity)
+{
+    m_ui->resizeDiskImageButton->setEnabled(capacity > m_diskImageCapacity);
+}
+
 void MerSdkDetailsWidget::onResizeDiskImageButtonClicked()
 {
-    emit resizeDiskImageButtonClicked(m_diskImageUuid,
-                                      m_ui->diskImageCapacitySpinBox->minimum(),
-                                      m_ui->diskImageCapacitySpinBox->value());
+    emit resizeDiskImageButtonClicked(m_diskImageUuid, m_ui->diskImageCapacitySpinBox->value());
 }
 
 void MerSdkDetailsWidget::onAuthorizeSshKeyButtonClicked()

--- a/src/plugins/mer/mersdkdetailswidget.h
+++ b/src/plugins/mer/mersdkdetailswidget.h
@@ -61,6 +61,7 @@ public:
     void setSrcFolderChooserPath(const QString &path);
     void setDiskImageCapacity(int capacity);
     void resetDiskImageCapacity();
+    void setResizeButtonEnabled(bool enabled);
 
 signals:
     void generateSshKey(const QString &key);
@@ -70,15 +71,15 @@ signals:
     void sshTimeoutChanged(int timeout);
     void headlessCheckBoxToggled(bool checked);
     void srcFolderApplyButtonClicked(const QString &path);
-    void resizeDiskImageButtonClicked(const QString &uuid, int capacity, int newCapacity);
+    void resizeDiskImageButtonClicked(const QString &uuid, int capacity);
 
 private slots:
     void onAuthorizeSshKeyButtonClicked();
     void onGenerateSshKeyButtonClicked();
     void onPathChooserEditingFinished();
     void onSrcFolderApplyButtonClicked();
+    void onDiskImageCapacityChanged(int capacity);
     void onResizeDiskImageButtonClicked();
-
 
 private:
     Ui::MerSdkDetailsWidget *m_ui;

--- a/src/plugins/mer/mersdkdetailswidget.h
+++ b/src/plugins/mer/mersdkdetailswidget.h
@@ -59,6 +59,8 @@ public:
     void setSshTimeout(int timeout);
     void setHeadless(bool enabled);
     void setSrcFolderChooserPath(const QString &path);
+    void setDiskImageCapacity(int capacity);
+    void resetDiskImageCapacity();
 
 signals:
     void generateSshKey(const QString &key);
@@ -68,12 +70,14 @@ signals:
     void sshTimeoutChanged(int timeout);
     void headlessCheckBoxToggled(bool checked);
     void srcFolderApplyButtonClicked(const QString &path);
+    void resizeDiskImageButtonClicked(const QString &uuid, int capacity, int newCapacity);
 
 private slots:
     void onAuthorizeSshKeyButtonClicked();
     void onGenerateSshKeyButtonClicked();
     void onPathChooserEditingFinished();
     void onSrcFolderApplyButtonClicked();
+    void onResizeDiskImageButtonClicked();
 
 
 private:
@@ -81,6 +85,8 @@ private:
     QIcon m_invalidIcon;
     QIcon m_warningIcon;
     bool m_updateConnection;
+    QString m_diskImageUuid;
+    int m_diskImageCapacity;
 };
 
 } // Internal

--- a/src/plugins/mer/mersdkdetailswidget.ui
+++ b/src/plugins/mer/mersdkdetailswidget.ui
@@ -6,26 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1004</width>
-    <height>483</height>
+    <width>448</width>
+    <height>654</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
-    <number>0</number>
-   </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <widget class="QScrollArea" name="scrollArea">
      <property name="sizePolicy">
@@ -42,11 +30,11 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>988</width>
-        <height>487</height>
+        <width>422</width>
+        <height>628</height>
        </rect>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
+      <layout class="QVBoxLayout" name="verticalLayout">
        <item>
         <widget class="QGroupBox" name="groupBox">
          <property name="title">
@@ -55,9 +43,6 @@
          <layout class="QFormLayout" name="formLayout">
           <property name="fieldGrowthPolicy">
            <enum>QFormLayout::ExpandingFieldsGrow</enum>
-          </property>
-          <property name="formAlignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
           </property>
           <item row="0" column="0">
            <widget class="QLabel" name="nameLabel">
@@ -110,14 +95,14 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
+          <item row="3" column="0">
            <widget class="QLabel" name="wwwPorLabel">
             <property name="text">
              <string>Web port:</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="3" column="1">
            <widget class="QLabel" name="wwwPortLabelText">
             <property name="text">
              <string>8080</string>
@@ -127,14 +112,14 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
+          <item row="4" column="0">
            <widget class="QLabel" name="targetsLabel">
             <property name="text">
              <string>Targets:</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
+          <item row="4" column="1">
            <widget class="QLabel" name="targetsListLabel">
             <property name="text">
              <string>None</string>
@@ -144,14 +129,14 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="label">
+          <item row="5" column="0">
+           <widget class="QLabel" name="headlessLabel">
             <property name="text">
              <string>No window:</string>
             </property>
            </widget>
           </item>
-          <item row="6" column="1">
+          <item row="5" column="1">
            <widget class="QCheckBox" name="headlessCheckBox">
             <property name="toolTip">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled the virtual machine will be run in a windowless mode (default).&lt;/p&gt;&lt;p&gt;Changing this setting requires restarting the virtual machine.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -160,6 +145,59 @@
              <string/>
             </property>
            </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="diskImageCapacityLabel">
+            <property name="text">
+             <string>Disk image capacity:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <layout class="QHBoxLayout" name="diskImageCapacityLayout">
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QSpinBox" name="diskImageCapacitySpinBox">
+              <property name="suffix">
+               <string>MB</string>
+              </property>
+              <property name="minimum">
+               <number>0</number>
+              </property>
+              <property name="maximum">
+               <number>65536</number>
+              </property>
+              <property name="value">
+               <number>0</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="resizeDiskImageButton">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-weight:600;&quot;&gt;Resize the disk image.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;The new capacity has to be greater than the current capacity of the disk image. If the SDK virtual machine is running, it will be stopped before resizing the disk image.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Resize</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>10</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>
@@ -170,6 +208,9 @@
           <string>Shared folders</string>
          </property>
          <layout class="QFormLayout" name="formLayout_2">
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::ExpandingFieldsGrow</enum>
+          </property>
           <item row="0" column="0">
            <widget class="QLabel" name="srcFolderLabel">
             <property name="text">
@@ -318,15 +359,8 @@
          </property>
          <layout class="QFormLayout" name="formLayout_3">
           <property name="fieldGrowthPolicy">
-           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+           <enum>QFormLayout::ExpandingFieldsGrow</enum>
           </property>
-          <item row="0" column="0">
-           <widget class="QLabel" name="userNameLabel">
-            <property name="text">
-             <string>Username:</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="1">
            <widget class="QLabel" name="userNameLabelText">
             <property name="text">
@@ -372,6 +406,32 @@
             </item>
            </layout>
           </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="sshTimeoutLabel">
+            <property name="text">
+             <string>SSH timeout:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QSpinBox" name="sshTimeoutSpinBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="suffix">
+             <string>s</string>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>999</number>
+            </property>
+           </widget>
+          </item>
           <item row="3" column="0">
            <widget class="QLabel" name="statusLabel">
             <property name="text">
@@ -403,29 +463,10 @@
             </item>
            </layout>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_2">
+          <item row="0" column="0">
+           <widget class="QLabel" name="userNameLabel">
             <property name="text">
-             <string>SSH timeout:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QSpinBox" name="sshTimeoutSpinBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="suffix">
-             <string>s</string>
-            </property>
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>999</number>
+             <string>Username:</string>
             </property>
            </widget>
           </item>

--- a/src/plugins/mer/mervirtualboxmanager.h
+++ b/src/plugins/mer/mervirtualboxmanager.h
@@ -47,6 +47,14 @@ public:
     bool headless;
 };
 
+class VirtualMachineDiskImageInfo
+{
+public:
+    VirtualMachineDiskImageInfo() : capacity(0) {}
+    QString uuid;
+    int capacity;
+};
+
 class MerVirtualBoxManager : public QObject
 {
     Q_OBJECT
@@ -57,9 +65,12 @@ public:
     static bool isVirtualMachineRegistered(const QString &vmName);
     static QStringList fetchRegisteredVirtualMachines();
     static VirtualMachineInfo fetchVirtualMachineInfo(const QString &vmName);
+    static VirtualMachineDiskImageInfo fetchVirtualMachineDiskImageInfo(const QString &vmName);
     static void startVirtualMachine(const QString &vmName, bool headless);
     static void shutVirtualMachine(const QString &vmName);
     static bool updateSharedFolder(const QString &vmName, const QString &mountName, const QString &newFolder);
+    static bool resizeDiskImage(const QString &vmName, const QString &uuid, int capacity);
+
 private:
     MerVirtualBoxManager(QObject *parent = 0);
 


### PR DESCRIPTION
The SDK details widget now has a spin box for showing and setting the maximum capacity of a virtual machine disk image file. Resizing is enabled by entering a value greater than the current capacity.

`MerVirtualBoxManager` now has support for querying the current capacity of the primary disk image associated with a virtual machine.

Parts of `MerOptionsWidget` and `MerVirtualBoxManager` were also refactored to take advantage of new private utility methods introduced as a part of this pull request.

**Note:** This feature is not particularly useful until corresponding support for detecting and acting on increased disk capacity is added the build engine virtual machine. For this reason, the resizing functionality can be disabled by defining `MER_NO_BUILD_ENGINE_RESIZE` when building Qt Creator.

![Disk image capacity option in SDK details](https://cloud.githubusercontent.com/assets/11955922/7794333/ebf3f2cc-02d1-11e5-91c4-89d511c1f6eb.png)

![Illegal capacity warning dialog](https://cloud.githubusercontent.com/assets/11955922/7794335/ec1f8d10-02d1-11e5-9f56-af39438285a9.png)

![Close running virtual machine dialog](https://cloud.githubusercontent.com/assets/11955922/7794334/ec1d7732-02d1-11e5-8564-d93e054b240b.png)
