### PR TITLE
Make web UI port editable in SDK details widget (Fixes JB#30222)

### DIFF
--- a/src/plugins/mer/meroptionswidget.cpp
+++ b/src/plugins/mer/meroptionswidget.cpp
@@ -291,36 +291,15 @@ void MerOptionsWidget::onWwwPortApplyButtonClicked(int port)
 {
     MerSdk *sdk = m_sdks[m_virtualMachine];
 
-    const bool vmIsOff = sdk->connection()->isVirtualMachineOff();
-    const bool vmWillBeClosed = !vmIsOff && showCloseVirtualMachineDialog(tr("Virtual machine must be closed before the web port can be changed."));
-    bool updateOk = false;
-
-    if (vmIsOff || vmWillBeClosed) {
-        // Disable the WWW port "Change" button so that it cannot be clicked
-        // multiple times while the port change is in progress.
-        m_ui->sdkDetailsWidget->setWwwPortApplyButtonEnabled(false);
-
-        if (sdk->connection()->lockDown(true)) {
-            updateOk = MerVirtualBoxManager::updateWwwPort(m_virtualMachine, port);
-            sdk->connection()->lockDown(false);
-        }
-
-        if (updateOk) {
-            m_ui->sdkDetailsWidget->setWwwPort(port);
-            sdk->setWwwPort(port);
-
-            if (vmWillBeClosed && showStartVirtualMachineDialog(tr("Web port successfully changed to %1.").arg(port))) {
-                sdk->connection()->connectTo();
-            }
-        } else {
-            QMessageBox::warning(this,
-                                 tr("Changing web port failed!"),
-                                 tr("Unable to change web port to %1").arg(port));
-        }
-    }
-
-    if (!updateOk) {
+    if (MerVirtualBoxManager::updateWwwPort(m_virtualMachine, port)) {
+        m_ui->sdkDetailsWidget->setWwwPort(port);
+        sdk->setWwwPort(port);
+    } else {
         m_ui->sdkDetailsWidget->resetWwwPort();
+
+        QMessageBox::warning(this,
+                             tr("Changing web port failed!"),
+                             tr("Unable to change web port to %1").arg(port));
     }
 }
 

--- a/src/plugins/mer/meroptionswidget.cpp
+++ b/src/plugins/mer/meroptionswidget.cpp
@@ -258,10 +258,10 @@ void MerOptionsWidget::onSrcFolderApplyButtonClicked(const QString &newFolder)
     }
 
     const bool vmIsOff = sdk->connection()->isVirtualMachineOff();
-    const bool vmWasClosed = !vmIsOff && showCloseVirtualMachineDialog(tr("Virtual machine must be closed before the source folder can be changed."));
+    const bool vmWillBeClosed = !vmIsOff && showCloseVirtualMachineDialog(tr("Virtual machine must be closed before the source folder can be changed."));
     bool updateOk = false;
 
-    if (vmIsOff || vmWasClosed) {
+    if (vmIsOff || vmWillBeClosed) {
         if (sdk->connection()->lockDown(true)) {
             updateOk = MerVirtualBoxManager::updateSharedFolder(m_virtualMachine, QLatin1String("src1"), newFolder);
             sdk->connection()->lockDown(false);
@@ -271,7 +271,7 @@ void MerOptionsWidget::onSrcFolderApplyButtonClicked(const QString &newFolder)
             // Remember to update this value
             sdk->setSharedSrcPath(newFolder);
 
-            if (vmWasClosed && showStartVirtualMachineDialog(tr("Alternative source folder for %1 changed to %2.").arg(m_virtualMachine).arg(newFolder))) {
+            if (vmWillBeClosed && showStartVirtualMachineDialog(tr("Alternative source folder for %1 changed to %2.").arg(m_virtualMachine).arg(newFolder))) {
                 sdk->connection()->connectTo();
             }
         } else {
@@ -292,10 +292,10 @@ void MerOptionsWidget::onWwwPortApplyButtonClicked(int port)
     MerSdk *sdk = m_sdks[m_virtualMachine];
 
     const bool vmIsOff = sdk->connection()->isVirtualMachineOff();
-    const bool vmWasClosed = !vmIsOff && showCloseVirtualMachineDialog(tr("Virtual machine must be closed before the web port can be changed."));
+    const bool vmWillBeClosed = !vmIsOff && showCloseVirtualMachineDialog(tr("Virtual machine must be closed before the web port can be changed."));
     bool updateOk = false;
 
-    if (vmIsOff || vmWasClosed) {
+    if (vmIsOff || vmWillBeClosed) {
         // Disable the WWW port "Change" button so that it cannot be clicked
         // multiple times while the port change is in progress.
         m_ui->sdkDetailsWidget->setWwwPortApplyButtonEnabled(false);
@@ -309,7 +309,7 @@ void MerOptionsWidget::onWwwPortApplyButtonClicked(int port)
             m_ui->sdkDetailsWidget->setWwwPort(port);
             sdk->setWwwPort(port);
 
-            if (vmWasClosed && showStartVirtualMachineDialog(tr("Web port successfully changed to %1.").arg(port))) {
+            if (vmWillBeClosed && showStartVirtualMachineDialog(tr("Web port successfully changed to %1.").arg(port))) {
                 sdk->connection()->connectTo();
             }
         } else {

--- a/src/plugins/mer/meroptionswidget.h
+++ b/src/plugins/mer/meroptionswidget.h
@@ -68,7 +68,12 @@ private slots:
     void onSshTimeoutChanged(int timeout);
     void onHeadlessCheckBoxToggled(bool checked);
     void onSrcFolderApplyButtonClicked(const QString &path);
+    void onWwwPortApplyButtonClicked(int port);
     void update();
+
+private:
+    bool showCloseVirtualMachineDialog(const QString &informativeText);
+    bool showStartVirtualMachineDialog(const QString &informativeText);
 
 private:
     Ui::MerOptionsWidget *m_ui;

--- a/src/plugins/mer/mersdkdetailswidget.cpp
+++ b/src/plugins/mer/mersdkdetailswidget.cpp
@@ -38,6 +38,7 @@ MerSdkDetailsWidget::MerSdkDetailsWidget(QWidget *parent)
     , m_invalidIcon(QLatin1String(":/mer/images/compile_error.png"))
     , m_warningIcon(QLatin1String(":/mer/images/warning.png"))
     , m_updateConnection(false)
+    , m_wwwPort(8080)
 {
     m_ui->setupUi(this);
 

--- a/src/plugins/mer/mersdkdetailswidget.cpp
+++ b/src/plugins/mer/mersdkdetailswidget.cpp
@@ -92,11 +92,6 @@ void MerSdkDetailsWidget::resetWwwPort()
     m_ui->wwwPortApplyButton->setEnabled(false);
 }
 
-void MerSdkDetailsWidget::setWwwPortApplyButtonEnabled(bool enabled)
-{
-    m_ui->wwwPortApplyButton->setEnabled(enabled);
-}
-
 void MerSdkDetailsWidget::setSdk(const MerSdk *sdk)
 {
     m_ui->nameLabelText->setText(sdk->virtualMachineName());

--- a/src/plugins/mer/mersdkdetailswidget.cpp
+++ b/src/plugins/mer/mersdkdetailswidget.cpp
@@ -49,6 +49,8 @@ MerSdkDetailsWidget::MerSdkDetailsWidget(QWidget *parent)
     connect(m_ui->sshTimeoutSpinBox, SIGNAL(valueChanged(int)), SIGNAL(sshTimeoutChanged(int)));
     connect(m_ui->headlessCheckBox, SIGNAL(toggled(bool)), SIGNAL(headlessCheckBoxToggled(bool)));
     connect(m_ui->srcFolderApplyButton, SIGNAL(clicked()), SLOT(onSrcFolderApplyButtonClicked()));
+    connect(m_ui->wwwPortSpinBox, SIGNAL(valueChanged(int)), SLOT(onWwwPortChanged(int)));
+    connect(m_ui->wwwPortApplyButton, SIGNAL(clicked()), SLOT(onWwwPortApplyButtonClicked()));
 
     m_ui->privateKeyPathChooser->setExpectedKind(Utils::PathChooser::File);
     m_ui->privateKeyPathChooser->setPromptDialogTitle(tr("Select SSH Key"));
@@ -73,11 +75,31 @@ void MerSdkDetailsWidget::setSrcFolderChooserPath(const QString& path)
     m_ui->srcFolderPathChooser->setPath(QDir::toNativeSeparators(path));
 }
 
+void MerSdkDetailsWidget::setWwwPort(int port)
+{
+    if ((port >= m_ui->wwwPortSpinBox->minimum()) && (port <= m_ui->wwwPortSpinBox->maximum())) {
+        m_wwwPort = port;
+
+        m_ui->wwwPortSpinBox->setValue(m_wwwPort);
+        m_ui->wwwPortApplyButton->setEnabled(false);
+    }
+}
+
+void MerSdkDetailsWidget::resetWwwPort()
+{
+    m_ui->wwwPortSpinBox->setValue(m_wwwPort);
+    m_ui->wwwPortApplyButton->setEnabled(false);
+}
+
+void MerSdkDetailsWidget::setWwwPortApplyButtonEnabled(bool enabled)
+{
+    m_ui->wwwPortApplyButton->setEnabled(enabled);
+}
+
 void MerSdkDetailsWidget::setSdk(const MerSdk *sdk)
 {
     m_ui->nameLabelText->setText(sdk->virtualMachineName());
     m_ui->sshPortLabelText->setText(QString::number(sdk->sshPort()));
-    m_ui->wwwPortLabelText->setText(QString::number(sdk->wwwPort()));
     m_ui->homeFolderPathLabel->setText(QDir::toNativeSeparators(sdk->sharedHomePath()));
     m_ui->targetFolderPathLabel->setText(QDir::toNativeSeparators(sdk->sharedTargetsPath()));
     m_ui->sshFolderPathLabel->setText(QDir::toNativeSeparators(sdk->sharedSshPath()));
@@ -101,6 +123,8 @@ void MerSdkDetailsWidget::setSdk(const MerSdk *sdk)
     }
 
     m_ui->userNameLabelText->setText(sdk->userName());
+
+    setWwwPort(sdk->wwwPort());
 }
 
 void MerSdkDetailsWidget::setTestButtonEnabled(bool enabled)
@@ -141,6 +165,16 @@ void MerSdkDetailsWidget::onSrcFolderApplyButtonClicked()
         }
         emit srcFolderApplyButtonClicked(path);
     }
+}
+
+void MerSdkDetailsWidget::onWwwPortChanged(int port)
+{
+    m_ui->wwwPortApplyButton->setEnabled(m_wwwPort != port);
+}
+
+void MerSdkDetailsWidget::onWwwPortApplyButtonClicked()
+{
+    emit wwwPortApplyButtonClicked(m_ui->wwwPortSpinBox->value());
 }
 
 void MerSdkDetailsWidget::onAuthorizeSshKeyButtonClicked()

--- a/src/plugins/mer/mersdkdetailswidget.h
+++ b/src/plugins/mer/mersdkdetailswidget.h
@@ -59,6 +59,9 @@ public:
     void setSshTimeout(int timeout);
     void setHeadless(bool enabled);
     void setSrcFolderChooserPath(const QString &path);
+    void setWwwPort(int port);
+    void resetWwwPort();
+    void setWwwPortApplyButtonEnabled(bool enabled);
 
 signals:
     void generateSshKey(const QString &key);
@@ -68,12 +71,15 @@ signals:
     void sshTimeoutChanged(int timeout);
     void headlessCheckBoxToggled(bool checked);
     void srcFolderApplyButtonClicked(const QString &path);
+    void wwwPortApplyButtonClicked(int port);
 
 private slots:
     void onAuthorizeSshKeyButtonClicked();
     void onGenerateSshKeyButtonClicked();
     void onPathChooserEditingFinished();
     void onSrcFolderApplyButtonClicked();
+    void onWwwPortChanged(int port);
+    void onWwwPortApplyButtonClicked();
 
 
 private:
@@ -81,6 +87,7 @@ private:
     QIcon m_invalidIcon;
     QIcon m_warningIcon;
     bool m_updateConnection;
+    int m_wwwPort;
 };
 
 } // Internal

--- a/src/plugins/mer/mersdkdetailswidget.h
+++ b/src/plugins/mer/mersdkdetailswidget.h
@@ -61,7 +61,6 @@ public:
     void setSrcFolderChooserPath(const QString &path);
     void setWwwPort(int port);
     void resetWwwPort();
-    void setWwwPortApplyButtonEnabled(bool enabled);
 
 signals:
     void generateSshKey(const QString &key);

--- a/src/plugins/mer/mersdkdetailswidget.ui
+++ b/src/plugins/mer/mersdkdetailswidget.ui
@@ -6,26 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1004</width>
-    <height>483</height>
+    <width>475</width>
+    <height>708</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
-    <number>0</number>
-   </property>
    <item>
     <widget class="QScrollArea" name="scrollArea">
      <property name="sizePolicy">
@@ -37,18 +25,18 @@
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents_2">
+     <widget class="QWidget" name="scrollAreaContentsWidget">
       <property name="geometry">
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>988</width>
-        <height>487</height>
+        <width>449</width>
+        <height>682</height>
        </rect>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
+      <layout class="QVBoxLayout" name="scrollAreaContentsLayout">
        <item>
-        <widget class="QGroupBox" name="groupBox">
+        <widget class="QGroupBox" name="virtualMachineGroupBox">
          <property name="title">
           <string>Virtual machine</string>
          </property>
@@ -68,6 +56,12 @@
           </item>
           <item row="0" column="1">
            <widget class="QLabel" name="nameLabelText">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="text">
              <string/>
             </property>
@@ -85,6 +79,12 @@
           </item>
           <item row="1" column="1">
            <widget class="QLabel" name="hostLabelText">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="text">
              <string>localhost</string>
             </property>
@@ -102,6 +102,12 @@
           </item>
           <item row="2" column="1">
            <widget class="QLabel" name="sshPortLabelText">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="text">
              <string>2222</string>
             </property>
@@ -110,32 +116,65 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
+          <item row="3" column="0">
            <widget class="QLabel" name="wwwPorLabel">
             <property name="text">
              <string>Web port:</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
-           <widget class="QLabel" name="wwwPortLabelText">
-            <property name="text">
-             <string>8080</string>
-            </property>
-            <property name="textInteractionFlags">
-             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-            </property>
-           </widget>
+          <item row="3" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QSpinBox" name="wwwPortSpinBox">
+              <property name="minimum">
+               <number>1024</number>
+              </property>
+              <property name="maximum">
+               <number>65535</number>
+              </property>
+              <property name="value">
+               <number>8080</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="wwwPortApplyButton">
+              <property name="text">
+               <string>Change</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
           </item>
-          <item row="5" column="0">
+          <item row="4" column="0">
            <widget class="QLabel" name="targetsLabel">
             <property name="text">
              <string>Targets:</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
+          <item row="4" column="1">
            <widget class="QLabel" name="targetsListLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="text">
              <string>None</string>
             </property>
@@ -144,14 +183,14 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="label">
+          <item row="5" column="0">
+           <widget class="QLabel" name="headlessLabel">
             <property name="text">
              <string>No window:</string>
             </property>
            </widget>
           </item>
-          <item row="6" column="1">
+          <item row="5" column="1">
            <widget class="QCheckBox" name="headlessCheckBox">
             <property name="toolTip">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled the virtual machine will be run in a windowless mode (default).&lt;/p&gt;&lt;p&gt;Changing this setting requires restarting the virtual machine.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -165,11 +204,17 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox_2">
+        <widget class="QGroupBox" name="sharedFoldersGroupBox">
          <property name="title">
           <string>Shared folders</string>
          </property>
-         <layout class="QFormLayout" name="formLayout_2">
+         <layout class="QFormLayout" name="sharedFoldersLayout">
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::ExpandingFieldsGrow</enum>
+          </property>
+          <property name="formAlignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          </property>
           <item row="0" column="0">
            <widget class="QLabel" name="srcFolderLabel">
             <property name="text">
@@ -178,19 +223,32 @@
            </widget>
           </item>
           <item row="0" column="1">
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <widget class="Utils::PathChooser" name="srcFolderPathChooser" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;The alternative source folder path.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Your projects can be located under your home folder or under this folder.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <layout class="QHBoxLayout" name="srcFolderPushButtonLayout">
             <item>
-             <widget class="Utils::PathChooser" name="srcFolderPathChooser" native="true">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
               </property>
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;The alternative source folder path.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Your projects can be located under your home folder or under this folder.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
               </property>
-             </widget>
+             </spacer>
             </item>
             <item>
              <widget class="QPushButton" name="srcFolderApplyButton">
@@ -204,7 +262,7 @@
             </item>
            </layout>
           </item>
-          <item row="1" column="0">
+          <item row="2" column="0">
            <widget class="QLabel" name="homeFolderLabel">
             <property name="enabled">
              <bool>false</bool>
@@ -214,36 +272,16 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="2" column="1">
            <widget class="QLabel" name="homeFolderPathLabel">
             <property name="enabled">
              <bool>false</bool>
             </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-            <property name="textInteractionFlags">
-             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="targetFolderLabel">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="text">
-             <string>Targets folder:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QLabel" name="targetFolderPathLabel">
-            <property name="enabled">
-             <bool>false</bool>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
             <property name="text">
              <string/>
@@ -257,19 +295,25 @@
            </widget>
           </item>
           <item row="3" column="0">
-           <widget class="QLabel" name="sshFolderLabel">
+           <widget class="QLabel" name="targetFolderLabel">
             <property name="enabled">
              <bool>false</bool>
             </property>
             <property name="text">
-             <string>Ssh folder:</string>
+             <string>Targets folder:</string>
             </property>
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="QLabel" name="sshFolderPathLabel">
+           <widget class="QLabel" name="targetFolderPathLabel">
             <property name="enabled">
              <bool>false</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
             <property name="text">
              <string/>
@@ -283,6 +327,38 @@
            </widget>
           </item>
           <item row="4" column="0">
+           <widget class="QLabel" name="sshFolderLabel">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>Ssh folder:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLabel" name="sshFolderPathLabel">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
            <widget class="QLabel" name="configFolderLabel">
             <property name="enabled">
              <bool>false</bool>
@@ -292,10 +368,16 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="5" column="1">
            <widget class="QLabel" name="configFolderPathLabel">
             <property name="enabled">
              <bool>false</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
             <property name="text">
              <string/>
@@ -312,13 +394,16 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox_3">
+        <widget class="QGroupBox" name="connectionGroupBox">
          <property name="title">
           <string>Connection</string>
          </property>
-         <layout class="QFormLayout" name="formLayout_3">
+         <layout class="QFormLayout" name="connectionLayout">
           <property name="fieldGrowthPolicy">
-           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+           <enum>QFormLayout::ExpandingFieldsGrow</enum>
+          </property>
+          <property name="formAlignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
           </property>
           <item row="0" column="0">
            <widget class="QLabel" name="userNameLabel">
@@ -329,6 +414,12 @@
           </item>
           <item row="0" column="1">
            <widget class="QLabel" name="userNameLabelText">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="text">
              <string/>
             </property>
@@ -345,16 +436,29 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <layout class="QHBoxLayout" name="horizontalLayout">
+           <widget class="Utils::PathChooser" name="privateKeyPathChooser" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <layout class="QHBoxLayout" name="sshKeyPushButtonLayout">
             <item>
-             <widget class="Utils::PathChooser" name="privateKeyPathChooser" native="true">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
+             <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
               </property>
-             </widget>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
             </item>
             <item>
              <widget class="QPushButton" name="generateSshKeyPushButton">
@@ -373,14 +477,40 @@
            </layout>
           </item>
           <item row="3" column="0">
+           <widget class="QLabel" name="sshTimeoutLabel">
+            <property name="text">
+             <string>SSH timeout:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QSpinBox" name="sshTimeoutSpinBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="suffix">
+             <string>s</string>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>999</number>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
            <widget class="QLabel" name="statusLabel">
             <property name="text">
              <string>Status:</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item row="4" column="1">
+           <layout class="QHBoxLayout" name="statusLayout">
             <item>
              <widget class="QLabel" name="statusLabelText">
               <property name="sizePolicy">
@@ -403,47 +533,8 @@
             </item>
            </layout>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>SSH timeout:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QSpinBox" name="sshTimeoutSpinBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="suffix">
-             <string>s</string>
-            </property>
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>999</number>
-            </property>
-           </widget>
-          </item>
          </layout>
         </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
        </item>
       </layout>
      </widget>

--- a/src/plugins/mer/mervirtualboxmanager.cpp
+++ b/src/plugins/mer/mervirtualboxmanager.cpp
@@ -39,6 +39,7 @@ const char SHOWVMINFO[] = "showvminfo";
 const char MACHINE_READABLE[] = "--machinereadable";
 const char STARTVM[] = "startvm";
 const char CONTROLVM[] = "controlvm";
+const char MODIFYVM[] = "modifyvm";
 const char ACPI_POWER_BUTTON[] = "acpipowerbutton";
 const char TYPE[] = "--type";
 const char HEADLESS[] = "headless";
@@ -47,6 +48,10 @@ const char SHARE_NAME[] = "--name";
 const char REMOVE_SHARED[] = "remove";
 const char HOSTPATH[] = "--hostpath";
 const char ADD_SHARED[] = "add";
+const char NAT_PORT_FORWARD[] = "--natpf1";
+const char NAT_PORT_FORWARD_DELETE[] = "delete";
+const char NAT_PORT_FORWARD_RULE_NAME[] = "guestwww";
+const char NAT_PORT_FORWARD_RULE_FORMAT[] = "guestwww,tcp,127.0.0.1,%1,,9292";
 
 namespace Mer {
 namespace Internal {
@@ -162,6 +167,36 @@ bool MerVirtualBoxManager::updateSharedFolder(const QString &vmName, const QStri
     aproc.start(vBoxManagePath(), aargs);
     if (!aproc.waitForFinished()) {
         qWarning() << "VBoxManage failed to add " << mountName;
+        return false;
+    }
+
+    return true;
+}
+
+bool MerVirtualBoxManager::updateWwwPort(const QString &vmName, int port)
+{
+    QStringList rargs;
+    rargs.append(QLatin1String(MODIFYVM));
+    rargs.append(vmName);
+    rargs.append(QLatin1String(NAT_PORT_FORWARD));
+    rargs.append(QLatin1String(NAT_PORT_FORWARD_DELETE));
+    rargs.append(QLatin1String(NAT_PORT_FORWARD_RULE_NAME));
+    QProcess rproc;
+    rproc.start(vBoxManagePath(), rargs);
+    if (!rproc.waitForFinished()) {
+        qWarning() << "VBoxManage failed to remove NAT port forwarding rule " << QLatin1String(NAT_PORT_FORWARD_RULE_NAME);
+        return false;
+    }
+
+    QStringList aargs;
+    aargs.append(QLatin1String(MODIFYVM));
+    aargs.append(vmName);
+    aargs.append(QLatin1String(NAT_PORT_FORWARD));
+    aargs.append(QString::fromLatin1(NAT_PORT_FORWARD_RULE_FORMAT).arg(port));
+    QProcess aproc;
+    aproc.start(vBoxManagePath(), aargs);
+    if (!aproc.waitForFinished()) {
+        qWarning() << "VBoxManage failed to add NAT port forwarding rule for port " << port;
         return false;
     }
 

--- a/src/plugins/mer/mervirtualboxmanager.cpp
+++ b/src/plugins/mer/mervirtualboxmanager.cpp
@@ -39,7 +39,6 @@ const char SHOWVMINFO[] = "showvminfo";
 const char MACHINE_READABLE[] = "--machinereadable";
 const char STARTVM[] = "startvm";
 const char CONTROLVM[] = "controlvm";
-const char MODIFYVM[] = "modifyvm";
 const char ACPI_POWER_BUTTON[] = "acpipowerbutton";
 const char TYPE[] = "--type";
 const char HEADLESS[] = "headless";
@@ -48,7 +47,7 @@ const char SHARE_NAME[] = "--name";
 const char REMOVE_SHARED[] = "remove";
 const char HOSTPATH[] = "--hostpath";
 const char ADD_SHARED[] = "add";
-const char NAT_PORT_FORWARD[] = "--natpf1";
+const char NAT_PORT_FORWARD[] = "natpf1";
 const char NAT_PORT_FORWARD_DELETE[] = "delete";
 const char NAT_PORT_FORWARD_RULE_NAME[] = "guestwww";
 const char NAT_PORT_FORWARD_RULE_FORMAT[] = "guestwww,tcp,127.0.0.1,%1,,9292";
@@ -176,7 +175,7 @@ bool MerVirtualBoxManager::updateSharedFolder(const QString &vmName, const QStri
 bool MerVirtualBoxManager::updateWwwPort(const QString &vmName, int port)
 {
     QStringList rargs;
-    rargs.append(QLatin1String(MODIFYVM));
+    rargs.append(QLatin1String(CONTROLVM));
     rargs.append(vmName);
     rargs.append(QLatin1String(NAT_PORT_FORWARD));
     rargs.append(QLatin1String(NAT_PORT_FORWARD_DELETE));
@@ -189,7 +188,7 @@ bool MerVirtualBoxManager::updateWwwPort(const QString &vmName, int port)
     }
 
     QStringList aargs;
-    aargs.append(QLatin1String(MODIFYVM));
+    aargs.append(QLatin1String(CONTROLVM));
     aargs.append(vmName);
     aargs.append(QLatin1String(NAT_PORT_FORWARD));
     aargs.append(QString::fromLatin1(NAT_PORT_FORWARD_RULE_FORMAT).arg(port));

--- a/src/plugins/mer/mervirtualboxmanager.h
+++ b/src/plugins/mer/mervirtualboxmanager.h
@@ -60,6 +60,7 @@ public:
     static void startVirtualMachine(const QString &vmName, bool headless);
     static void shutVirtualMachine(const QString &vmName);
     static bool updateSharedFolder(const QString &vmName, const QString &mountName, const QString &newFolder);
+    static bool updateWwwPort(const QString &vmName, int port);
 private:
     MerVirtualBoxManager(QObject *parent = 0);
 


### PR DESCRIPTION
Replaced the static web UI port label with a spin box in `MerSdkDetailsWidget` to make it possible for the user to change the port of the build engine web UI.

![qt-creator-mer-change-www-port](https://cloud.githubusercontent.com/assets/11955922/8424202/763ee42a-1eff-11e5-9377-a5276a0e7afc.png)

The initial value for the spin box is the port configured by the installer (8080). The user can specify any port in the range [1024..65535].

No attempt is made to verify that the port is actually free. The SDK configuration and the NAT port forwarding rule of the “MerSDK” virtual machine are updated as soon as the user pressed the “Change” button.

In `MerOptionsWidget`, the new slot `onWwwPortApplyButtonClicked(int)` takes care of closing the virtual machine for the duration of the port update operation and restarting it, if necessary.

The existing slot `onSrcFolderApplyButtonClicked()` was refactored to use the new private utility methods `showCloseVirtualMachineDialog()` and `showStartVirtualMachineDialog()`, as the functionality of these two slots is very similar.

Note that this pull request also includes a narrower layout for the SDK details widget requiring no horizontal scrolling. This fixes [JB#29309](https://bz.jollamobile.com/show_bug.cgi?id=29309) and obsoletes sailfish-sdk/sailfish-qtcreator pull request #36.
