### PR TITLE
MiniProjectTargetSelector: Dynamically choose best elide mode

### DIFF
--- a/src/plugins/projectexplorer/miniprojecttargetselector.cpp
+++ b/src/plugins/projectexplorer/miniprojecttargetselector.cpp
@@ -60,6 +60,7 @@
 #include <QAction>
 #include <QItemDelegate>
 
+#include <array>
 
 static QIcon createCenteredIcon(const QIcon &icon, const QIcon &overlay)
 {
@@ -110,6 +111,8 @@ private:
     void paint(QPainter *painter,
                const QStyleOptionViewItem &option,
                const QModelIndex &index) const;
+    QString elide(const QString &text, const QStringList &otherTexts, const QFontMetrics &fm,
+            int width) const;
     ListWidget *m_listWidget;
 };
 
@@ -149,8 +152,14 @@ void TargetSelectorDelegate::paint(QPainter *painter,
 
     QFontMetrics fm(option.font);
     QString text = index.data(Qt::DisplayRole).toString();
+    QStringList otherTexts;
+    for (QModelIndex other = index.sibling(0, 0); other.isValid(); other = other.sibling(other.row() + 1, 0)) {
+        if (other != index)
+            otherTexts.append(other.data(Qt::DisplayRole).toString());
+    }
+
     painter->setPen(creatorTheme()->color(Theme::MiniProjectTargetSelectorTextColor));
-    QString elidedText = fm.elidedText(text, Qt::ElideMiddle, option.rect.width() - 12);
+    QString elidedText = elide(text, otherTexts, fm, option.rect.width() - 12);
     if (elidedText != text)
         const_cast<QAbstractItemModel *>(index.model())->setData(index, text, Qt::ToolTipRole);
     else
@@ -158,6 +167,37 @@ void TargetSelectorDelegate::paint(QPainter *painter,
     painter->drawText(option.rect.left() + 6, option.rect.top() + (option.rect.height() - fm.height()) / 2 + fm.ascent(), elidedText);
 
     painter->restore();
+}
+
+QString TargetSelectorDelegate::elide(const QString &text, const QStringList &otherTexts,
+        const QFontMetrics &fm, int width) const
+{
+    std::array<Qt::TextElideMode, 3> modes{
+        Qt::ElideMiddle,
+        Qt::ElideRight,
+        Qt::ElideLeft
+    };
+
+    int minDuplicates = std::numeric_limits<int>::max();
+    QString retv;
+
+    foreach (const Qt::TextElideMode mode, modes) {
+        QString elidedText = fm.elidedText(text, mode, width);
+        int duplicates = 0;
+        foreach (const QString &otherText, otherTexts) {
+            QString otherElidedText = fm.elidedText(otherText, mode, width);
+            if (elidedText == otherElidedText)
+                ++duplicates;
+        }
+        if (duplicates < minDuplicates) {
+            minDuplicates = duplicates;
+            retv = elidedText;
+            if (duplicates == 0)
+                break;
+        }
+    }
+
+    return retv;
 }
 
 ////////


### PR DESCRIPTION
Eliding two strings can hide just the part where they differ. When this
happens, try the other text elide modes.