### PR TITLE
QtSupport: Copy examples to a writable location unconditionally

### DIFF
--- a/src/plugins/qtsupport/gettingstartedwelcomepage.cpp
+++ b/src/plugins/qtsupport/gettingstartedwelcomepage.cpp
@@ -168,6 +168,7 @@ void ExamplesWelcomePage::openProject(const ExampleItem &item)
     if (!proFileInfo.exists())
         return;
 
+#if 0
     // If the Qt is a distro Qt on Linux, it will not be writable, hence compilation will fail
     // Same if it is installed in non-writable location for other reasons
     const bool needsCopy = withNTFSPermissions<bool>([proFileInfo] {
@@ -177,6 +178,7 @@ void ExamplesWelcomePage::openProject(const ExampleItem &item)
                 || !QFileInfo(pathInfo.path()).isWritable() /* shadow build directory */;
     });
     if (needsCopy)
+#endif
         proFile = copyToAlternativeLocation(proFileInfo, filesToOpen, item.dependencies);
 
     // don't try to load help and files if loading the help request is being cancelled


### PR DESCRIPTION
This would cause a build error with Sailfish/Mer projects where the SDK
installation directory is usually out of the configured projects
directory.