### PR TITLE
Mark QmakeAndroidSupport plugin as experimental

### DIFF
--- a/src/plugins/qmakeandroidsupport/QmakeAndroidSupport.json.in
+++ b/src/plugins/qmakeandroidsupport/QmakeAndroidSupport.json.in
@@ -2,6 +2,7 @@
     \"Name\" : \"QmakeAndroidSupport\",
     \"Version\" : \"$$QTCREATOR_VERSION\",
     \"CompatVersion\" : \"$$QTCREATOR_COMPAT_VERSION\",
+    \"Experimental\" : true,
     \"HiddenByDefault\" : true,
     \"Vendor\" : \"The Qt Company Ltd\",
     \"Copyright\" : \"(C) $$QTCREATOR_COPYRIGHT_YEAR The Qt Company Ltd\",


### PR DESCRIPTION
This hidden plugin caused loading of the Android plugin which was
already marked as experiemntal.