### PR TITLE
meremulatormodedialog: Fix compile error

### DIFF
--- a/src/plugins/mer/meremulatormodedialog.cpp
+++ b/src/plugins/mer/meremulatormodedialog.cpp
@@ -40,6 +40,7 @@
 #include <projectexplorer/target.h>
 #include <utils/qtcassert.h>
 
+#include <QAction>
 #include <QDesktopWidget>
 #include <QPushButton>
 


### PR DESCRIPTION
meremulatormodedialog: Fix compile error

```
meremulatormodedialog.cpp:54:32:
error: invalid use of incomplete type ‘class QAction’
       m_action(new QAction(this)),
                                ^
In file included from /QT/5.11.1/gcc_64/include/QtGui/QList:1:0,
                 from ../../plugins/projectexplorer/abi.h:30,
                 from merdevice.h:26,
                 from meremulatordevice.h:26,
                 from meremulatormodedialog.h:36,
                 from meremulatormodedialog.cpp:30:
/Qt/5.11.1/gcc_64/include/QtGui/qevent.h:62:7:
note: forward declaration of ‘class QAction’
```