### PR TITLE
QmakeProjectManager: Watch wildcard directories for changes

### DIFF
--- a/src/plugins/qmakeprojectmanager/qmakeparsernodes.cpp
+++ b/src/plugins/qmakeprojectmanager/qmakeparsernodes.cpp
@@ -42,6 +42,7 @@
 #include <qtsupport/profilereader.h>
 
 #include <utils/algorithm.h>
+#include <utils/filesystemwatcher.h>
 #include <utils/qtcprocess.h>
 #include <utils/mimetypes/mimedatabase.h>
 #include <utils/stringutils.h>
@@ -151,6 +152,7 @@ public:
     InstallsList installsList;
     QHash<Variable, QStringList> newVarValues;
     QStringList errors;
+    QSet<QString> directoriesWithWildcards;
 };
 
 } // namespace Internal
@@ -1395,14 +1397,14 @@ QmakeEvalResult *QmakeProFile::evaluate(const QmakeEvalInput &input)
                 const QStringList vPathsExact = fullVPaths(
                             baseVPathsExact, exactReader, qmakeVariable, input.projectDir);
                 auto sourceFiles = exactReader->absoluteFileValues(
-                            qmakeVariable, input.projectDir, vPathsExact, &handled);
+                            qmakeVariable, input.projectDir, vPathsExact, &handled, result->directoriesWithWildcards);
                 exactSourceFiles[qmakeVariable] = sourceFiles;
                 extractSources(proToResult, &result->includedFiles.result, sourceFiles, type);
             }
             const QStringList vPathsCumulative = fullVPaths(
                         baseVPathsCumulative, cumulativeReader, qmakeVariable, input.projectDir);
             auto sourceFiles = cumulativeReader->absoluteFileValues(
-                        qmakeVariable, input.projectDir, vPathsCumulative, &handled);
+                        qmakeVariable, input.projectDir, vPathsCumulative, &handled, result->directoriesWithWildcards);
             cumulativeSourceFiles[qmakeVariable] = sourceFiles;
             extractSources(proToResult, &result->includedFiles.result, sourceFiles, type);
         }
@@ -1622,6 +1624,33 @@ void QmakeProFile::applyEvaluate(QmakeEvalResult *evalResult)
 
         m_displayName = singleVariableValue(Variable::QmakeProjectName);
     } // result == EvalOk
+
+    if (!result->directoriesWithWildcards.isEmpty()) {
+        if (!m_wildcardWatcher) {
+            m_wildcardWatcher = std::make_unique<Utils::FileSystemWatcher>();
+            QObject::connect(
+                m_wildcardWatcher.get(), &Utils::FileSystemWatcher::directoryChanged,
+                [this]() {
+                    scheduleUpdate();
+                });
+        }
+        m_wildcardWatcher->addDirectories(
+            Utils::filtered<QStringList>(result->directoriesWithWildcards.toList(),
+                [this](const QString &path) {
+                    return !m_wildcardWatcher->watchesDirectory(path);
+                }), Utils::FileSystemWatcher::WatchAllChanges);
+    }
+    if (m_wildcardWatcher) {
+        if (result->directoriesWithWildcards.isEmpty()) {
+            m_wildcardWatcher.reset();
+        } else {
+            m_wildcardWatcher->removeDirectories(
+                Utils::filtered<QStringList>(m_wildcardWatcher->directories(),
+                    [&result](const QString &path) {
+                        return !result->directoriesWithWildcards.contains(path);
+                    }));
+        }
+    }
 
     setParseInProgress(false);
 

--- a/src/plugins/qmakeprojectmanager/qmakeparsernodes.h
+++ b/src/plugins/qmakeprojectmanager/qmakeparsernodes.h
@@ -39,7 +39,11 @@
 
 #include <memory>
 
-namespace Utils { class FileName; }
+namespace Utils {
+class FileName;
+class FileSystemWatcher;
+} // namespace Utils;
+
 namespace QtSupport { class ProFileReader; }
 namespace ProjectExplorer { class RunConfiguration; }
 
@@ -367,6 +371,8 @@ private:
     TargetInformation m_qmakeTargetInformation;
     Utils::FileNameList m_subProjectsNotToDeploy;
     InstallsList m_installsList;
+
+    std::unique_ptr<Utils::FileSystemWatcher> m_wildcardWatcher;
 
     // Async stuff
     QFutureWatcher<Internal::QmakeEvalResult *> m_parseFutureWatcher;

--- a/src/shared/proparser/profileevaluator.cpp
+++ b/src/shared/proparser/profileevaluator.cpp
@@ -139,7 +139,7 @@ QStringList ProFileEvaluator::absolutePathValues(
 
 QVector<ProFileEvaluator::SourceFile> ProFileEvaluator::absoluteFileValues(
         const QString &variable, const QString &baseDirectory, const QStringList &searchDirs,
-        QHash<ProString, bool> *handled) const
+        QHash<ProString, bool> *handled, QSet<QString> &directoriesWithWildcards) const
 {
     QMakeVfs::VfsFlags flags = (d->m_cumulative ? QMakeVfs::VfsCumulative : QMakeVfs::VfsExact);
     QVector<SourceFile> result;
@@ -186,6 +186,9 @@ QVector<ProFileEvaluator::SourceFile> ProFileEvaluator::absoluteFileValues(
                     foreach (const QString &fn, theDir.entryList(QStringList(wildcard)))
                         if (fn != QLatin1String(".") && fn != QLatin1String(".."))
                             result << SourceFile{absDir + QLatin1Char('/') + fn, str.sourceFile()};
+                    QString directoryWithWildcard(absDir);
+                    directoryWithWildcard.detach();
+                    directoriesWithWildcards.insert(directoryWithWildcard);
                 } // else if (acceptMissing)
             }
         }

--- a/src/shared/proparser/profileevaluator.h
+++ b/src/shared/proparser/profileevaluator.h
@@ -86,7 +86,7 @@ public:
     QStringList absolutePathValues(const QString &variable, const QString &baseDirectory) const;
     QVector<SourceFile> absoluteFileValues(
             const QString &variable, const QString &baseDirectory, const QStringList &searchDirs,
-            QHash<ProString, bool> *handled) const;
+            QHash<ProString, bool> *handled, QSet<QString> &directoriesWithWildcards) const;
     QString propertyValue(const QString &val) const;
     static QStringList sourcesToFiles(const QVector<SourceFile> &sources);
 


### PR DESCRIPTION
If e.g. DISTFILES contains wildcards, watch the directory for changes.

Fixes: QTCREATORBUG-21603
Change-Id: Ia6e8c94ab7b74e0404776ba1d7d9b10eb3b643de
Reviewed-by: Oswald Buddenhagen <oswald.buddenhagen@qt.io>
Reviewed-by: Tobias Hunger <tobias.hunger@qt.io>
Reviewed-by: Orgad Shaneh <orgads@gmail.com>
(cherry picked from commit 76262814b6a10604cf84c3ecc85b2792af1b942d)