### PR TITLE
Mer: Write ssh port to devices.xml

### DIFF
--- a/src/plugins/mer/merdevicexmlparser.cpp
+++ b/src/plugins/mer/merdevicexmlparser.cpp
@@ -64,6 +64,7 @@ const char SSH_PATH[] = "sshkeypath";
 const char SUBNET[] = "subnet";
 const char MAC[] = "mac";
 const char INDEX[] = "index";
+const char SSH_PORT[] = "sshport";
 
 namespace Mer {
 
@@ -392,7 +393,12 @@ MerDevicesXmlWriter::MerDevicesXmlWriter(const QString &fileName,
         if(!data.m_mac.isEmpty()) {
             writer.writeStartElement(QLatin1String(MAC));
             writer.writeCharacters(data.m_mac);
-            writer.writeEndElement(); // ssh
+            writer.writeEndElement(); // mac
+        }
+        if(!data.m_sshPort.isEmpty()) {
+            writer.writeStartElement(QLatin1String(SSH_PORT));
+            writer.writeCharacters(data.m_sshPort);
+            writer.writeEndElement(); // sshport
         }
         writer.writeEndElement(); // device
     }

--- a/src/plugins/mer/merdevicexmlparser.h
+++ b/src/plugins/mer/merdevicexmlparser.h
@@ -76,6 +76,7 @@ public:
     QString m_name;
     QString m_type;
     QString m_index;
+    QString m_sshPort;
 };
 
 class MerEngineData

--- a/src/plugins/mer/mersdkmanager.cpp
+++ b/src/plugins/mer/mersdkmanager.cpp
@@ -637,6 +637,7 @@ void MerSdkManager::updateDevices()
                 xmlData.m_ip = device->sshParameters().host();
                 xmlData.m_name = device->displayName();
                 xmlData.m_type = QLatin1String("real");
+                xmlData.m_sshPort.setNum(device->sshParameters().port());
                 QFileInfo file(device->sshParameters().privateKeyFile);
                 QString path = QDir::toNativeSeparators(file.dir().absolutePath());
                 if(!device->sharedSshPath().isEmpty())


### PR DESCRIPTION
The settings UI allows one to change the ssh port of a device. This
setting was not used by the build engine.