### PR TITLE
Mer: Use kits added with sdktool instead of creating new ones

### DIFF
--- a/src/plugins/mer/mersdk.cpp
+++ b/src/plugins/mer/mersdk.cpp
@@ -529,17 +529,25 @@ bool MerSdk::addTarget(const MerTarget &target)
     QScopedPointer<MerQtVersion> version(target.createQtVersion());
     if (version.isNull())
         return false;
-    std::unique_ptr<Kit> kit = target.createKit();
-    if (!kit)
+
+    Kit* kitptr = target.kit();
+    std::unique_ptr<Kit> kit(nullptr);
+    if (!kitptr) {
+        kit = std::make_unique<Kit>();
+        kitptr = kit.get();
+    }
+
+    if (!target.finalizeKitCreation(kitptr))
         return false;
 
     ToolChainManager::registerToolChain(toolchain.data());
     ToolChainManager::registerToolChain(toolchain_c.data());
     QtVersionManager::addVersion(version.data());
-    QtKitInformation::setQtVersion(kit.get(), version.data());
-    ToolChainKitInformation::setToolChain(kit.get(), toolchain.data());
-    ToolChainKitInformation::setToolChain(kit.get(), toolchain_c.data());
-    KitManager::registerKit(std::move(kit));
+    QtKitInformation::setQtVersion(kitptr, version.data());
+    ToolChainKitInformation::setToolChain(kitptr, toolchain.data());
+    ToolChainKitInformation::setToolChain(kitptr, toolchain_c.data());
+    if (kit)
+        KitManager::registerKit(std::move(kit));
     toolchain.take();
     toolchain_c.take();
     version.take();

--- a/src/plugins/mer/mertarget.h
+++ b/src/plugins/mer/mertarget.h
@@ -74,7 +74,9 @@ public:
 
     bool fromMap(const QVariantMap &data);
     QVariantMap toMap() const;
-    std::unique_ptr<ProjectExplorer::Kit> createKit() const;
+    ProjectExplorer::Kit *kit() const;
+
+    bool finalizeKitCreation(ProjectExplorer::Kit *k) const;
     void ensureDebuggerIsSet(ProjectExplorer::Kit *k) const;
     MerQtVersion* createQtVersion() const;
     MerToolChain* createToolChain(Core::Id l) const;


### PR DESCRIPTION
Sometimes non-mer kits were visible in the configuration wizard, e.g.
"Desktop" kit. These could not be used for Sailfish OS projects, so it's
better to deregister them.