### PR TITLE
Mer: Fix target path for emulator's private SSH keys

### DIFF
--- a/src/plugins/mer/meremulatordevice.h
+++ b/src/plugins/mer/meremulatordevice.h
@@ -158,6 +158,8 @@ private:
     void setVideoMode();
     void updateDconfDb();
 
+    QString privateKeyFile(const QString &user) const;
+
 private:
     QSharedPointer<MerConnection> m_connection; // all clones share the connection
     QString m_factorySnapshot;


### PR DESCRIPTION
After introducing possibility to install multiple emulators, the
sharedConfigPath of an emulator is no more equal to the sharedConfigPath
of the build engine, while that one is searched for the private keys
later.