### PR TITLE
QmakePM: Only schedule update when files are added/removed. JB#45377

### DIFF
--- a/src/plugins/qmakeprojectmanager/qmakeparsernodes.cpp
+++ b/src/plugins/qmakeprojectmanager/qmakeparsernodes.cpp
@@ -1630,25 +1630,38 @@ void QmakeProFile::applyEvaluate(QmakeEvalResult *evalResult)
             m_wildcardWatcher = std::make_unique<Utils::FileSystemWatcher>();
             QObject::connect(
                 m_wildcardWatcher.get(), &Utils::FileSystemWatcher::directoryChanged,
-                [this]() {
-                    scheduleUpdate();
+                [this](QString path) {
+                    QStringList directoryContents = QDir(path).entryList();
+                    if (m_wildcardDirectoryContents.value(path) != directoryContents) {
+                        m_wildcardDirectoryContents.insert(path, directoryContents);
+                        scheduleUpdate();
+                    }
                 });
         }
-        m_wildcardWatcher->addDirectories(
-            Utils::filtered<QStringList>(result->directoriesWithWildcards.toList(),
-                [this](const QString &path) {
-                    return !m_wildcardWatcher->watchesDirectory(path);
-                }), Utils::FileSystemWatcher::WatchAllChanges);
+        const QStringList directoriesToAdd = Utils::filtered<QStringList>(
+            result->directoriesWithWildcards.toList(),
+            [this](const QString &path) {
+                return !m_wildcardWatcher->watchesDirectory(path);
+            });
+        for (QString path : directoriesToAdd)
+            m_wildcardDirectoryContents.insert(path, QDir(path).entryList());
+        m_wildcardWatcher->addDirectories(directoriesToAdd,
+                                          Utils::FileSystemWatcher::WatchModifiedDate);
     }
     if (m_wildcardWatcher) {
         if (result->directoriesWithWildcards.isEmpty()) {
             m_wildcardWatcher.reset();
+            m_wildcardDirectoryContents.clear();
         } else {
-            m_wildcardWatcher->removeDirectories(
-                Utils::filtered<QStringList>(m_wildcardWatcher->directories(),
+            const QStringList directoriesToRemove =
+                Utils::filtered<QStringList>(
+                    m_wildcardWatcher->directories(),
                     [&result](const QString &path) {
                         return !result->directoriesWithWildcards.contains(path);
-                    }));
+                    });
+            m_wildcardWatcher->removeDirectories(directoriesToRemove);
+            for (QString path : directoriesToRemove)
+                m_wildcardDirectoryContents.remove(path);
         }
     }
 

--- a/src/plugins/qmakeprojectmanager/qmakeparsernodes.h
+++ b/src/plugins/qmakeprojectmanager/qmakeparsernodes.h
@@ -373,6 +373,7 @@ private:
     InstallsList m_installsList;
 
     std::unique_ptr<Utils::FileSystemWatcher> m_wildcardWatcher;
+    QMap<QString, QStringList> m_wildcardDirectoryContents;
 
     // Async stuff
     QFutureWatcher<Internal::QmakeEvalResult *> m_parseFutureWatcher;


### PR DESCRIPTION
When a file is saved, the directory is also touched. If files are not
added or removed, it is not necessary to reparse the project.

Change-Id: I718db68362d41ba936629be880f739ad79b8cb6f
Fixes: QTCREATORBUG-22361
Reviewed-by: Christian Kandeler <christian.kandeler@qt.io>
(cherry-picked from commit ecd386c67b3e3c00546df4624b53a5c36e7623ff)