### PR TITLE
Mer: Not initialize factory snapshot when no snapshots exist

### DIFF
--- a/src/plugins/mer/meremulatordevicewizardpages.cpp
+++ b/src/plugins/mer/meremulatordevicewizardpages.cpp
@@ -207,7 +207,8 @@ void MerEmualtorVMPage::handleEmulatorVmChanged(const QString &vmName)
     else
         m_ui->vdiCapacityLabelEdit->setText(tr("none"));
 
-    m_factorySnapshot = info.snapshots.first();
+    if (!info.snapshots.isEmpty())
+        m_factorySnapshot = info.snapshots.first();
 }
 
 


### PR DESCRIPTION
MerEmualtorVMPage::handleEmulatorVmChanged sets the first snapshot
as factory snapshot. If there are no snapshots, this would cause
Qt Creator to crash.