### PR TITLE
QMakePM: Disable error dialog when deleting a file with wildcard

### DIFF
--- a/src/plugins/qmakeprojectmanager/qmakeparsernodes.h
+++ b/src/plugins/qmakeprojectmanager/qmakeparsernodes.h
@@ -327,6 +327,8 @@ public:
 
     void asyncUpdate();
 
+    bool isFileFromWildcard(const QString &fileName) const;
+
 private:
     void setParseInProgress(bool b);
     void setValidParseRecursive(bool b);


### PR DESCRIPTION
When a file is removed from project, an error dialog was displayed if
the project file is not changed. If the file had been included in the
project because of a wildcard, this logic fails.