### PR TITLE
Fix qt.conf for macOS

### DIFF
--- a/dist/installer/mac/qt.conf
+++ b/dist/installer/mac/qt.conf
@@ -1,5 +1,5 @@
 [Paths]
-Binaries = MacOS
-Imports = Imports/qtquick1
-Qml2Imports = Imports/qtquick2
-Plugins = PlugIns
+Binaries = ../MacOS
+Imports = ../Imports/qtquick1
+Qml2Imports = ../Imports/qtquick2
+Plugins = ../PlugIns


### PR DESCRIPTION
Fixes qtc-askpass failing to find Qt platform plugin.

Not using Prefix=.. as none of the other qt.conf variants uses it.