### PR TITLE
Mer: Set last guest size hint when changing emulator mode

### DIFF
--- a/src/plugins/mer/meremulatormodedialog.cpp
+++ b/src/plugins/mer/meremulatormodedialog.cpp
@@ -224,15 +224,19 @@ bool MerEmulatorModeDialog::execDialog()
     if (!result)
         goto end;
 
+    if (!m_emulator.data()->connection()->isVirtualMachineOff()
+        && m_ui->restartEmulatorCheckBox->isChecked()) {
+        m_emulator.data()->connection()->lockDown(true);
+    }
+
     m_emulator.data()->setDeviceModel(m_ui->deviceModelComboBox->currentDeviceModel());
     m_emulator.data()->setOrientation(m_ui->portraitRadioButton->isChecked()
                                ? Qt::Vertical
                                : Qt::Horizontal);
     m_emulator.data()->setViewScaled(m_ui->scaledViewModeRadioButton->isChecked());
 
-    if (!m_emulator.data()->connection()->isVirtualMachineOff()
+    if (m_emulator.data()->connection()->isVirtualMachineOff()
             && m_ui->restartEmulatorCheckBox->isChecked()) {
-        m_emulator.data()->connection()->lockDown(true);
         m_emulator.data()->connection()->lockDown(false);
         m_emulator.data()->connection()->connectTo();
     }

--- a/src/plugins/mer/mervirtualboxmanager.h
+++ b/src/plugins/mer/mervirtualboxmanager.h
@@ -110,6 +110,8 @@ public:
     static void getHostTotalMemorySizeMb(QObject *context, std::function<void(int)> slot);
     static int getHostTotalCpuCount();
 private:
+    static void setExtraData(const QString& vmName, const QString& keyword, const QString& data);
+
     static MerVirtualBoxManager *m_instance;
 };
 


### PR DESCRIPTION
Starting from 3.1.0 the Sailfish OS Emulator uses vboxdrmfb driver,
which uses GUI/LastGuestSizeHint for determining the video mode to use.
Also, in order to show the full screen even when it does not fit the
host display, Auto-resize Guest Display must be disabled.