### PR TITLE
jb46741

### DIFF
--- a/src/plugins/mer/mersdkdetailswidget.ui
+++ b/src/plugins/mer/mersdkdetailswidget.ui
@@ -53,6 +53,9 @@
           <string>Virtual machine</string>
          </property>
          <layout class="QFormLayout" name="formLayout">
+          <property name="formAlignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          </property>
           <item row="0" column="0">
            <widget class="QLabel" name="nameLabel">
             <property name="text">

--- a/src/plugins/mer/mervirtualmachinesettingswidget.ui
+++ b/src/plugins/mer/mervirtualmachinesettingswidget.ui
@@ -14,6 +14,9 @@
    <string>Form</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
+   <property name="formAlignment">
+    <set>Qt::AlignLeft</set>
+   </property>
    <property name="horizontalSpacing">
     <number>6</number>
    </property>


### PR DESCRIPTION
Force the left alignment on MacOS. The items are otherwise sometimes centered, if there's space for it.