### PR TITLE
Mer: add correct deploy step in MerRsyncDeployConfigurationFactory

### DIFF
--- a/src/plugins/mer/merdeployconfiguration.cpp
+++ b/src/plugins/mer/merdeployconfiguration.cpp
@@ -1,6 +1,7 @@
 /****************************************************************************
 **
 ** Copyright (C) 2012 - 2014 Jolla Ltd.
+** Copyright (C) 2019 Open Mobile Platform LLC.
 ** Contact: http://jolla.com/
 **
 ** This file is part of Qt Creator.
@@ -78,7 +79,7 @@ Core::Id MerRpmDeployConfigurationFactory::configurationId()
 MerRsyncDeployConfigurationFactory::MerRsyncDeployConfigurationFactory()
 {
     addInitialStep(MerPrepareTargetStep::stepId());
-    addInitialStep(MerMb2RpmDeployStep::stepId());
+    addInitialStep(MerMb2RsyncDeployStep::stepId());
 }
 
 QString MerRsyncDeployConfigurationFactory::displayName()


### PR DESCRIPTION
MerRsyncDeployConfigurationFactory added MerMb2RpmDeployStep instead of
MerMb2RsyncDeployStep, which caused the "Deploy by Copying Binaries" to
fail.