### PR TITLE
Sfdk: Hardcode IPv4 address for build engine and emulator

### DIFF
--- a/src/libs/sfdk/buildengine.cpp
+++ b/src/libs/sfdk/buildengine.cpp
@@ -542,6 +542,7 @@ void BuildEnginePrivate::syncWwwProxy()
 
     QStringList args;
     const QString eq("=");
+    args.append(Constants::MER_SSH_HOST + eq + sshParameters.host());
     args.append(Constants::MER_SSH_PORT + eq + QString::number(sshParameters.port()));
     args.append(Constants::MER_SSH_PRIVATE_KEY + eq + sshParameters.privateKeyFile);
     args.append(Constants::MER_SSH_SHARED_HOME + eq + sharedHomePath.toString());

--- a/src/libs/sfdk/sfdkconstants.h
+++ b/src/libs/sfdk/sfdkconstants.h
@@ -100,6 +100,7 @@ const char GCC_DUMP_INCLUDES_CACHE[] = "gcc.dumpincludes";
 
 // FIXME
 const char MER_SSH_DEVICE_NAME[] = "MER_SSH_DEVICE_NAME";
+const char MER_SSH_HOST[] = "MER_SSH_HOST";
 const char MER_SSH_PORT[] = "MER_SSH_PORT";
 const char MER_SSH_PRIVATE_KEY[] = "MER_SSH_PRIVATE_KEY";
 const char MER_SSH_SDK_TOOLS[] = "MER_SSH_SDK_TOOLS";

--- a/src/libs/sfdk/sfdkconstants.h
+++ b/src/libs/sfdk/sfdkconstants.h
@@ -120,7 +120,8 @@ const char DEFAULT_DEBUGGER_i486_FILENAME[] = "gdb-i486-meego-linux-gnu";
 const char DEFAULT_DEBUGGER_ARM_FILENAME[] = "gdb-armv7hl-meego-linux-gnueabi";
 const char DEBUGGER_FILENAME_PREFIX[] = "gdb-";
 
-const char BUILD_ENGINE_DEFAULT_HOST[] = "localhost";
+// hardcoded IPv4 address to prevent connecting via IPv6
+const char BUILD_ENGINE_DEFAULT_HOST[] = "127.0.0.1";
 const char BUILD_ENGINE_DEFAULT_USER_NAME[] = "mersdk";
 const int BUILD_ENGINE_DEFAULT_SSH_TIMEOUT = 30;
 
@@ -158,7 +159,8 @@ const char DEVICE_MODEL_DISPLAY_RESOLUTION[] = "DisplayResolution";
 const char DEVICE_MODEL_DISPLAY_SIZE[] = "DisplaySize";
 const char DEVICE_MODEL_DCONF[] = "Dconf";
 
-const char EMULATOR_DEFAULT_HOST[] = "localhost";
+// hardcoded IPv4 address to prevent connecting via IPv6
+const char EMULATOR_DEFAULT_HOST[] = "127.0.0.1";
 const char EMULATOR_DEFAULT_USER_NAME[] = "nemo";
 const int EMULATOR_DEFAULT_SSH_TIMEOUT = 30;
 

--- a/src/plugins/mer/mersdkkitinformation.cpp
+++ b/src/plugins/mer/mersdkkitinformation.cpp
@@ -205,6 +205,7 @@ void MerSdkKitInformation::addToEnvironment(const Kit *kit, Environment &env) co
 
         env.appendOrSet(QLatin1String(Sfdk::Constants::MER_SSH_USERNAME),
                         QLatin1String(Sfdk::Constants::BUILD_ENGINE_DEFAULT_USER_NAME));
+        env.appendOrSet(QLatin1String(Sfdk::Constants::MER_SSH_HOST), engine->virtualMachine()->sshParameters().host());
         env.appendOrSet(QLatin1String(Sfdk::Constants::MER_SSH_PORT), sshPort);
         env.appendOrSet(QLatin1String(Sfdk::Constants::MER_SSH_PRIVATE_KEY),
                 engine->virtualMachine()->sshParameters().privateKeyFile);

--- a/src/tools/merssh/main.cpp
+++ b/src/tools/merssh/main.cpp
@@ -66,6 +66,7 @@ void printUsage()
             << Sfdk::Constants::MER_SSH_DEVICE_NAME << endl
             << "evironment variables - connection parameters:" << endl
             << Sfdk::Constants::MER_SSH_USERNAME << endl
+            << Sfdk::Constants::MER_SSH_HOST << endl
             << Sfdk::Constants::MER_SSH_PORT << endl
             << Sfdk::Constants::MER_SSH_PRIVATE_KEY << endl;
 }
@@ -172,6 +173,7 @@ int main(int argc, char *argv[])
         QLatin1String(Sfdk::Constants::MER_SSH_SDK_TOOLS),
         QLatin1String(Sfdk::Constants::MER_SSH_DEVICE_NAME),
         QLatin1String(Sfdk::Constants::MER_SSH_USERNAME),
+        QLatin1String(Sfdk::Constants::MER_SSH_HOST),
         QLatin1String(Sfdk::Constants::MER_SSH_PORT),
         QLatin1String(Sfdk::Constants::MER_SSH_PRIVATE_KEY),
     };
@@ -213,7 +215,7 @@ int main(int argc, char *argv[])
     command->setDeviceName(environment.value(QLatin1String(Sfdk::Constants::MER_SSH_DEVICE_NAME)));
 
     QSsh::SshConnectionParameters parameters;
-    parameters.setHost(QLatin1String(Sfdk::Constants::BUILD_ENGINE_DEFAULT_HOST));
+    parameters.setHost(environment.value(QLatin1String(Sfdk::Constants::MER_SSH_HOST)));
     parameters.setUserName(environment.value(QLatin1String(Sfdk::Constants::MER_SSH_USERNAME)));
     parameters.setPort(environment.value(QLatin1String(Sfdk::Constants::MER_SSH_PORT)).toInt());
     parameters.privateKeyFile = environment.value(QLatin1String(Sfdk::Constants::MER_SSH_PRIVATE_KEY));


### PR DESCRIPTION
Using just the name localhost caused at least git ssh to try to
connect first via IPv6, causing unwanted delays.