### PR TITLE
Implement JSON-based wizard to create QML-files for Sailfish OS project

### DIFF
--- a/share/qtcreator/templates/wizards/sailfishos-qml-file/template.qml
+++ b/share/qtcreator/templates/wizards/sailfishos-qml-file/template.qml
@@ -1,4 +1,5 @@
 import QtQuick %{QtQuickVersion}
+%{QmlLibrariesImports}
 %{LocalImports}
 
 %{QmlBaseType} {

--- a/share/qtcreator/templates/wizards/sailfishos-qml-file/template.qml
+++ b/share/qtcreator/templates/wizards/sailfishos-qml-file/template.qml
@@ -1,0 +1,6 @@
+import QtQuick %{QtQuickVersion}
+
+%{QmlBaseType} {
+
+}
+

--- a/share/qtcreator/templates/wizards/sailfishos-qml-file/template.qml
+++ b/share/qtcreator/templates/wizards/sailfishos-qml-file/template.qml
@@ -1,4 +1,5 @@
 import QtQuick %{QtQuickVersion}
+%{LocalImports}
 
 %{QmlBaseType} {
 

--- a/share/qtcreator/templates/wizards/sailfishos-qml-file/wizard.json
+++ b/share/qtcreator/templates/wizards/sailfishos-qml-file/wizard.json
@@ -22,6 +22,11 @@
             "typeId": "File"
         },
         {
+            "trDisplayName": "Local Imports",
+            "trShortTitle": "Local Imports",
+            "typeId": "QmlLocalImports"
+        },
+        {
             "trDisplayName": "QML File Options",
             "trShortTitle": "QML File Options",
             "typeId": "Fields",

--- a/share/qtcreator/templates/wizards/sailfishos-qml-file/wizard.json
+++ b/share/qtcreator/templates/wizards/sailfishos-qml-file/wizard.json
@@ -5,7 +5,7 @@
     "category": "Sailfish OS",
     "trDescription": "Creates a QML file for Sailfish OS application project.",
     "trDisplayName": "QML File",
-    "trDisplayCategory": "Sailfish OS",
+    "trDisplayCategory": "%{SailfishOSFileWizardCategoryName}",
     "iconText": "QML",
     "enabled": "true",
 

--- a/share/qtcreator/templates/wizards/sailfishos-qml-file/wizard.json
+++ b/share/qtcreator/templates/wizards/sailfishos-qml-file/wizard.json
@@ -43,7 +43,7 @@
                    "type": "ComboBox",
                    "data":
                    {
-                       "items": [ "Item" ]
+                       "items": "%{QmlLibrariesTypes}"
                    }
                },
                {

--- a/share/qtcreator/templates/wizards/sailfishos-qml-file/wizard.json
+++ b/share/qtcreator/templates/wizards/sailfishos-qml-file/wizard.json
@@ -27,6 +27,11 @@
             "typeId": "QmlLocalImports"
         },
         {
+            "trDisplayName": "Import Libraries",
+            "trShortTitle": "Import Libraries",
+            "typeId": "ImportExternalLibraries"
+        },
+        {
             "trDisplayName": "QML File Options",
             "trShortTitle": "QML File Options",
             "typeId": "Fields",

--- a/share/qtcreator/templates/wizards/sailfishos-qml-file/wizard.json
+++ b/share/qtcreator/templates/wizards/sailfishos-qml-file/wizard.json
@@ -1,0 +1,71 @@
+{
+    "version": 1,
+    "supportedProjectTypes": [ ],
+    "id": "E.QmlFile",
+    "category": "Sailfish OS",
+    "trDescription": "Creates a QML file for Sailfish OS application project.",
+    "trDisplayName": "QML File",
+    "trDisplayCategory": "Sailfish OS",
+    "iconText": "QML",
+    "enabled": "true",
+
+    "options" : [
+        { "key": "TargetPath", "value": "%{Path}" },
+        { "key": "QmlFile", "value": "%{JS: Util.fileName('%{TargetPath}', 'qml')}" }
+    ],
+
+    "pages":
+    [
+        {
+            "trDisplayName": "Location",
+            "trShortTitle": "Location",
+            "typeId": "File"
+        },
+        {
+            "trDisplayName": "QML File Options",
+            "trShortTitle": "QML File Options",
+            "typeId": "Fields",
+            "data" :
+            [
+               {
+                   "name": "QmlBaseType",
+                   "trDisplayName": "Base type of QML document:",
+                   "type": "ComboBox",
+                   "data":
+                   {
+                       "items": [ "Item" ]
+                   }
+               },
+               {
+                   "name": "QtQuickVersion",
+                   "trDisplayName": "Qt Quick version:",
+                   "type": "ComboBox",
+                   "data":
+                   {
+                       "items": [ "2.6", "2.5", "2.4", "2.3", "2.2", "2.1", "2.0", "1.0" ]
+                   }
+               }
+            ]
+        },
+        {
+            "trDisplayName": "Project Management",
+            "trShortTitle": "Summary",
+            "typeId": "Summary"
+        }
+    ],
+
+    "generators":
+    [
+        {
+            "typeId": "File",
+            "data":
+            [
+                {
+                    "source": "template.qml",
+                    "target": "%{QmlFile}",
+                    "openInEditor": true
+                }
+            ]
+        }
+    ]
+}

--- a/share/qtcreator/translations/qtcreator_ru.ts
+++ b/share/qtcreator/translations/qtcreator_ru.ts
@@ -30038,6 +30038,26 @@ Use this only if you are prototyping. You cannot create a full application with 
         <source>Vertex Shader (OpenGL/ES 2.0)</source>
         <translation>Вершинный шейдер (OpenGL/ES 2.0)</translation>
     </message>
+    <message>
+        <source>Creates a QML file for Sailfish OS application project.</source>
+        <translation>Создание QML-файла для проекта приложения Sailfish OS.</translation>
+    </message>
+    <message>
+        <source>QML File</source>
+        <translation>QML-файл</translation>
+    </message>
+    <message>
+        <source>QML File Options</source>
+        <translation>Параметры QML-файла</translation>
+    </message>
+    <message>
+        <source>Base type of QML document:</source>
+        <translation>Базовый тип QML-документа:</translation>
+    </message>
+    <message>
+        <source>Qt Quick version:</source>
+        <translation>Версия Qt Quick:</translation>
+    </message>
 </context>
 <context>
     <name>ProjectExplorer::JsonWizardFactory</name>

--- a/share/qtcreator/translations/qtcreator_ru.ts
+++ b/share/qtcreator/translations/qtcreator_ru.ts
@@ -30058,6 +30058,14 @@ Use this only if you are prototyping. You cannot create a full application with 
         <source>Qt Quick version:</source>
         <translation>Версия Qt Quick:</translation>
     </message>
+    <message>
+        <source>Local Imports</source>
+        <translation>Локальные импорты</translation>
+    </message>
+    <message>
+        <source>&quot;data&quot; for a &quot;QmlLocalImports&quot; page needs to be unset or an empty object.</source>
+        <translation>Объект «data» для страницы «Локальные импорты» должен быть не задан или пустым.</translation>
+    </message>
 </context>
 <context>
     <name>ProjectExplorer::JsonWizardFactory</name>
@@ -50959,6 +50967,41 @@ Close the virtual machine now?</source>
         <location filename="vmconnection.cpp" line="495"/>
         <source>SSH conection with virtual machine &quot;%1&quot; has been lost: %2</source>
         <translation>SSH-соединение с виртуальной машиной &quot;%1&quot; потеряно: %2 %3</translation>
+    </message>
+</context>
+<context>
+    <name>SailfishOSWizards::Internal::QmlLocalImportsPage</name>
+    <message>
+        <source>Local Imports</source>
+        <translation>Локальные импорты</translation>
+    </message>
+    <message>
+        <source>Add file</source>
+        <translation>Добавить файл</translation>
+    </message>
+    <message>
+        <source>Add directory</source>
+        <translation>Добавить директорию</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Удалить</translation>
+    </message>
+    <message>
+        <source>Select one or more JavaScript files to import</source>
+        <translation>Выберите JavaScript-файлы для подключения в документ</translation>
+    </message>
+    <message>
+        <source>JavaScript files (*.js)</source>
+        <translation>JavaScript-файлы (*.js)</translation>
+    </message>
+    <message>
+        <source>Select directory containing QML files to import</source>
+        <translation>Выберите каталог, содержащий QML-файлы для импорта</translation>
+    </message>
+    <message>
+        <source>You do not need to add the target directory to local imports, because it is included by default.</source>
+        <translation>Вам не нужно добавлять целевой каталог в локальный импорт, потому что он включен по умолчанию.</translation>
     </message>
 </context>
 </TS>

--- a/share/qtcreator/translations/qtcreator_ru.ts
+++ b/share/qtcreator/translations/qtcreator_ru.ts
@@ -28989,6 +28989,10 @@ to project &quot;%2&quot;.</source>
         <source>Source and target are both empty.</source>
         <translation>Источник и назначение пусты.</translation>
     </message>
+    <message>
+        <source>%1 (&quot;%2&quot;) &quot;items&quot; is not a string.</source>
+        <translation>Поле «items» у %1 («%2») не является строкой.</translation>
+    </message>
 </context>
 <context>
     <name>ProjectExplorer::JsonKitsPage</name>
@@ -30065,6 +30069,14 @@ Use this only if you are prototyping. You cannot create a full application with 
     <message>
         <source>&quot;data&quot; for a &quot;QmlLocalImports&quot; page needs to be unset or an empty object.</source>
         <translation>Объект «data» для страницы «Локальные импорты» должен быть не задан или пустым.</translation>
+    </message>
+    <message>
+        <source>Import Libraries</source>
+        <translation>Импорт библиотек</translation>
+    </message>
+    <message>
+        <source>&quot;data&quot; for a &quot;ImportExternalLibraries&quot; page needs to be unset or an empty object.</source>
+        <translation>Объект «data» для страницы «Имборт библиотек» должен быть не задан или пустым.</translation>
     </message>
 </context>
 <context>
@@ -51002,6 +51014,40 @@ Close the virtual machine now?</source>
     <message>
         <source>You do not need to add the target directory to local imports, because it is included by default.</source>
         <translation>Вам не нужно добавлять целевой каталог в локальный импорт, потому что он включен по умолчанию.</translation>
+    </message>
+</context>
+<context>
+    <name>SailfishOSWizards::Internal::ImportExternalLibrariesPage</name>
+    <message>
+        <source>Import Libraries</source>
+        <translation>Импорт библиотек</translation>
+    </message>
+    <message>
+        <source>List of imported external standard libraries:</source>
+        <translation>Список импортируемых внешних стандартных библиотек:</translation>
+    </message>
+    <message>
+        <source>Add library</source>
+        <translation>Добавить библиотеку</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Удалить</translation>
+    </message>
+</context>
+<context>
+    <name>SailfishOSWizards::Internal::SelectItemsDialog</name>
+    <message>
+        <source>List of external libraries</source>
+        <translation>Список внешних библиотек</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation>Добавить</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
     </message>
 </context>
 </TS>

--- a/share/qtcreator/translations/qtcreator_ru.ts
+++ b/share/qtcreator/translations/qtcreator_ru.ts
@@ -51050,4 +51050,11 @@ Close the virtual machine now?</source>
         <translation>Отмена</translation>
     </message>
 </context>
+<context>
+    <name>SailfishOSWizards::Internal::SailfishOSWizardsPlugin</name>
+    <message>
+        <source>Category of a wizard for Sailfish OS files</source>
+        <translation>Категория мастера по созданию файлов для Sailfish OS</translation>
+    </message>
+</context>
 </TS>

--- a/src/libs/sfdk/asynchronous.cpp
+++ b/src/libs/sfdk/asynchronous.cpp
@@ -26,6 +26,7 @@
 #include <utils/qtcassert.h>
 
 #include <QTimer>
+#include <QTimerEvent>
 
 namespace Sfdk {
 

--- a/src/libs/sfdk/emulator.cpp
+++ b/src/libs/sfdk/emulator.cpp
@@ -38,6 +38,8 @@
 #include <utils/stringutils.h>
 
 #include <QTimer>
+#include <QPoint>
+#include <QRect>
 
 using namespace QSsh;
 using namespace Utils;

--- a/src/plugins/mer/merqtversion.h
+++ b/src/plugins/mer/merqtversion.h
@@ -26,6 +26,8 @@
 
 #include <qtsupport/baseqtversion.h>
 
+#include <QUrl>
+
 namespace Mer {
 namespace Internal {
 

--- a/src/plugins/mer/mertoolchain.h
+++ b/src/plugins/mer/mertoolchain.h
@@ -29,6 +29,8 @@
 #include <projectexplorer/gcctoolchain.h>
 #include <projectexplorer/headerpath.h>
 
+#include <QUrl>
+
 namespace Mer {
 namespace Internal {
 

--- a/src/plugins/plugins.pro
+++ b/src/plugins/plugins.pro
@@ -60,7 +60,8 @@ SUBDIRS   = \
     languageclient \
     cppcheck \
     compilationdatabaseprojectmanager \
-    qmlpreview
+    qmlpreview \
+    sailfishoswizards
 
 qtHaveModule(serialport) {
     SUBDIRS += serialterminal

--- a/src/plugins/projectexplorer/jsonwizard/jsonfieldpage_p.h
+++ b/src/plugins/projectexplorer/jsonwizard/jsonfieldpage_p.h
@@ -207,8 +207,11 @@ public:
 private:
     void addPossibleIconSize(const QIcon &icon);
     void updateIndex();
+    QList<QStandardItem *> createStandardItemListFromItemList(Utils::MacroExpander *expander);
+    QList<QStandardItem *> createStandardItemListFromItemsString(Utils::MacroExpander *expander);
 
     std::vector<std::unique_ptr<QStandardItem>> m_itemList;
+    QString m_itemsString = "";
     QStandardItemModel *m_itemModel = nullptr;
     QItemSelectionModel *m_selectionModel = nullptr;
     int m_index = -1;

--- a/src/plugins/projectexplorer/jsonwizard/jsonwizardfactory.cpp
+++ b/src/plugins/projectexplorer/jsonwizard/jsonwizardfactory.cpp
@@ -611,7 +611,7 @@ bool JsonWizardFactory::initialize(const QVariantMap &data, const QDir &baseDir,
         *errorMessage = tr("No displayCategory set.");
         return false;
     }
-    setDisplayCategory(strVal);
+    setDisplayCategory(Utils::globalMacroExpander()->expand(strVal));
 
     strVal = localizedString(data.value(QLatin1String(DESCRIPTION_KEY)));
     if (strVal.isEmpty()) {

--- a/src/plugins/sailfishoswizards/SailfishOSWizards.json.in
+++ b/src/plugins/sailfishoswizards/SailfishOSWizards.json.in
@@ -1,0 +1,18 @@
+{
+    \"Name\" : \"SailfishOSWizards\",
+    \"Version\" : \"$$QTCREATOR_VERSION\",
+    \"CompatVersion\" : \"$$QTCREATOR_COMPAT_VERSION\",
+    \"Vendor\" : \"OMP\",
+    \"Copyright\" : \"(C) OMP\",
+    \"License\" : [ \"Commercial Usage\",
+                  \"\",
+                  \"Licensees holding valid Qt Commercial licenses may use this plugin in accordance with the Qt Commercial License Agreement provided with the Software or, alternatively, in accordance with the terms contained in a written agreement between you and The Qt Company.\",
+                  \"\",
+                  \"GNU General Public License Usage\",
+                  \"\",
+                  \"Alternatively, this plugin may be used under the terms of the GNU General Public License version 3 as published by the Free Software Foundation with exceptions as appearing in the file LICENSE.GPL3-EXCEPT included in the packaging of this plugin. Please review the following information to ensure the GNU General Public License requirements will be met: https://www.gnu.org/licenses/gpl-3.0.html.\"
+    ],
+    \"Description\" : \"A set of useful pages for JSON-based wizards that ease the development of the applications for Sailfish OS\",
+    \"Url\" : \"http://omprussia.ru\",
+    $$dependencyList
+}

--- a/src/plugins/sailfishoswizards/data/qml-modules.json
+++ b/src/plugins/sailfishoswizards/data/qml-modules.json
@@ -1,0 +1,22 @@
+{
+    "QtPositioning 5.3": {
+        "layoutname": "Qt Positioning",
+        "qt": ["positioning"],
+        "yamlheader": "Requires:",
+        "specheader": "Requires",
+        "dependencies": ["sailfishsilica-qt5 >= 0.10.9", "qt5-qtdeclarative-import-positioning"],
+        "types": ["PositionSource"]
+	},
+    "QtSensors 5.11": {
+        "layoutname": "Qt Sensors",
+        "qt": ["sensors"],
+        "yamlheader": "Requires",
+        "specheader": "Requires",
+        "dependencies": ["sailfishsilica-qt5 >= 0.10.9", "qt5-qtdeclarative-import-sensors"],
+        "types": ["Accelerometer", "AccelerometerReading", "Altimeter", "AltimeterReading", "AmbientLightReading", "AmbientLightSensor", "AmbientTemperatureReading",
+        "AmbientTemperatureSensor", "Compass", "CompassReading", "DistanceReading", "DistanceSensor", "Gyroscope", "GyroscopeReading", "HolsterReading",
+        "HolsterSensor", "HumidityReading", "HumiditySensor", "IRProximityReading", "IRProximitySensor", "LidReading", "LidSensor", "LightReading", "LightSensor",
+        "Magnetometer", "MagnetometerReading", "OrientationReading", "OrientationSensor", "PressureReading", "PressureSensor", "ProximityReading", "ProximitySensor",
+        "RotationReading", "RotationSensor", "Sensor", "SensorGesture", "SensorGlobal", "SensorReading", "TapReading", "TapSensor", "TiltReading", "TiltSensor"]
+    }
+}

--- a/src/plugins/sailfishoswizards/forms/importexternallibrariespage.ui
+++ b/src/plugins/sailfishoswizards/forms/importexternallibrariespage.ui
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SailfishOSWizards::Internal::ImportExternalLibrariesPage</class>
+ <widget class="QWizardPage" name="SailfishOSWizards::Internal::ImportExternalLibrariesPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>595</width>
+    <height>317</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>WizardPage</string>
+  </property>
+  <property name="title">
+   <string>Import Libraries</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>List of imported external standard libraries:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QListView" name="libraryList"/>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetDefaultConstraint</enum>
+       </property>
+       <item>
+        <widget class="QPushButton" name="addButton">
+         <property name="text">
+          <string>Add library</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="removeButton">
+         <property name="text">
+          <string>Remove</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/plugins/sailfishoswizards/forms/qmllocalimportspage.ui
+++ b/src/plugins/sailfishoswizards/forms/qmllocalimportspage.ui
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SailfishOSWizards::Internal::QmlLocalImportsPage</class>
+ <widget class="QWizardPage" name="SailfishOSWizards::Internal::QmlLocalImportsPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>638</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>WizardPage</string>
+  </property>
+  <property name="title">
+   <string>Local Imports</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QListWidget" name="listImports"/>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QPushButton" name="addFileButton">
+         <property name="text">
+          <string>Add file</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="addDirButton">
+         <property name="text">
+          <string>Add directory</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="removeButton">
+         <property name="text">
+          <string>Remove</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/plugins/sailfishoswizards/forms/selectitemsdialog.ui
+++ b/src/plugins/sailfishoswizards/forms/selectitemsdialog.ui
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SailfishOSWizards::Internal::SelectItemsDialog</class>
+ <widget class="QDialog" name="SailfishOSWizards::Internal::SelectItemsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>List of external libraries</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QListView" name="itemList">
+       <property name="selectionMode">
+        <enum>QAbstractItemView::ExtendedSelection</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="addButton">
+         <property name="text">
+          <string>Add</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="cancelButton">
+         <property name="text">
+          <string>Cancel</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/plugins/sailfishoswizards/include/factories/importexternallibrariespagefactory.h
+++ b/src/plugins/sailfishoswizards/include/factories/importexternallibrariespagefactory.h
@@ -1,0 +1,34 @@
+/*
+ * Qt Creator plugin with wizards of the Sailfish OS projects.
+ * Copyright © 2020 FRUCT LLC.
+ */
+
+#ifndef IMPORTEXTERNALLIBRARIESPAGEFACTORY_H
+#define IMPORTEXTERNALLIBRARIESPAGEFACTORY_H
+
+#include <projectexplorer/jsonwizard/jsonwizardpagefactory.h>
+
+namespace SailfishOSWizards {
+namespace Internal {
+
+using namespace ProjectExplorer;
+
+/*!
+ * \brief ImportExternalLibrariesPageFactory class is a factory for creating and registering
+ * the 'ExternalLibraries' page type for JSON-based wizards.
+ */
+class ImportExternalLibrariesPageFactory : public JsonWizardPageFactory
+{
+
+public:
+    ImportExternalLibrariesPageFactory();
+
+    Utils::WizardPage *create(JsonWizard *wizard, Core::Id typeId,
+                              const QVariant &data) Q_DECL_OVERRIDE;
+    bool validateData(Core::Id typeId, const QVariant &data, QString *errorMessage) Q_DECL_OVERRIDE;
+};
+
+}
+}
+
+#endif // IMPORTEXTERNALLIBRARIESPAGEFACTORY_H

--- a/src/plugins/sailfishoswizards/include/factories/qmllocalimportspagefactory.h
+++ b/src/plugins/sailfishoswizards/include/factories/qmllocalimportspagefactory.h
@@ -1,0 +1,33 @@
+/*
+ * Qt Creator plugin with wizards of the Sailfish OS projects.
+ * Copyright © 2020 FRUCT LLC.
+ */
+
+#ifndef QMLLOCALIMPORTSPAGEFACTORY_H
+#define QMLLOCALIMPORTSPAGEFACTORY_H
+
+#include <projectexplorer/jsonwizard/jsonwizardpagefactory.h>
+
+namespace SailfishOSWizards {
+namespace Internal {
+
+using namespace ProjectExplorer;
+
+/*!
+ * \brief QmlLocalImportsPageFactory class is a factory for creating and registering
+ * the 'QmlLocalImports' page type for JSON-based wizards.
+ */
+class QmlLocalImportsPageFactory : public JsonWizardPageFactory
+{
+
+public:
+    QmlLocalImportsPageFactory();
+
+    Utils::WizardPage *create(JsonWizard *wizard, Core::Id typeId, const QVariant &data) Q_DECL_OVERRIDE;
+    bool validateData(Core::Id typeId, const QVariant &data, QString *errorMessage) Q_DECL_OVERRIDE;
+};
+
+}
+}
+
+#endif // QMLLOCALIMPORTSPAGEFACTORY_H

--- a/src/plugins/sailfishoswizards/include/models/externallibrary.h
+++ b/src/plugins/sailfishoswizards/include/models/externallibrary.h
@@ -1,0 +1,56 @@
+/*
+ * Qt Creator plugin with wizards of the Sailfish OS projects.
+ * Copyright © 2020 FRUCT LLC.
+ */
+
+#ifndef EXTERNALLIBRARY_H
+#define EXTERNALLIBRARY_H
+
+#include <QStringList>
+
+namespace SailfishOSWizards {
+namespace Internal {
+
+/*!
+ * \brief ExternalLibrary class is a model for external library.
+ * The class contains an information about the Qt external library.
+ */
+class ExternalLibrary
+{
+
+public:
+    ExternalLibrary() {}
+
+    void setName(const QString &name);
+    void setLayoutName(const QString &layoutName);
+    void setQtList(QStringList qtList);
+    void setDependencyList(QStringList dependencyList);
+    void setTypesList(QStringList types);
+    void setYamlHeader(const QString &yamlHeader);
+    void setSpecHeader(const QString &specHeader);
+
+    QString getName() const;
+    QString getLayoutName() const;
+    QStringList getQtList() const;
+    QStringList getDependencyList() const;
+    QStringList getTypesList() const;
+    QString getYamlHeader() const;
+    QString getSpecHeader() const;
+
+    void removeQtListItem(const int index);
+    void removeDependencyListItem(const int index);
+
+private:
+    QString m_name;
+    QString m_layoutName;
+    QString m_yamlHeader;
+    QString m_specHeader;
+    QStringList m_qtList;
+    QStringList m_dependencyList;
+    QStringList m_types;
+};
+
+}
+}
+
+#endif // EXTERNALLIBRARY_H

--- a/src/plugins/sailfishoswizards/include/models/externallibrarylistmodel.h
+++ b/src/plugins/sailfishoswizards/include/models/externallibrarylistmodel.h
@@ -1,0 +1,54 @@
+/*
+ * Qt Creator plugin with wizards of the Sailfish OS projects.
+ * Copyright © 2020 FRUCT LLC.
+ */
+
+#ifndef EXTERNALLIBRARYLISTMODEL_H
+#define EXTERNALLIBRARYLISTMODEL_H
+
+#include <QAbstractListModel>
+
+#include "externallibrary.h"
+
+namespace SailfishOSWizards {
+namespace Internal {
+
+/*!
+ * \brief ExternalLibraryListModel class is a list model of external libraries.
+ */
+class ExternalLibraryListModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+public:
+    enum ExternalLibraryRoles {
+        LayoutName = Qt::DisplayRole,
+        Name = Qt::UserRole + 1,
+        QtList = Qt::UserRole + 2,
+        YamlHeader = Qt::UserRole + 3,
+        SpecHeader = Qt::UserRole + 4,
+        DependencyList = Qt::UserRole + 5,
+        Types = Qt::UserRole + 6
+    };
+
+    explicit ExternalLibraryListModel(QObject *parent = nullptr);
+
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    int rowCount(const QModelIndex &parent) const Q_DECL_OVERRIDE;
+    bool removeRows(int pos, int count, const QModelIndex &parent = QModelIndex()) Q_DECL_OVERRIDE;
+
+    int size() const;
+    void clear();
+
+    ExternalLibrary getExternalLibrary(const int index) const;
+    void addExternalLibrary(ExternalLibrary externalLibrary);
+
+private:
+    QList<ExternalLibrary> m_externalLibraries;
+    QHash<int, QString> m_roles;
+};
+
+}
+}
+
+#endif // EXTERNALLIBRARYLISTMODEL_H

--- a/src/plugins/sailfishoswizards/include/pages/importexternallibrariespage.h
+++ b/src/plugins/sailfishoswizards/include/pages/importexternallibrariespage.h
@@ -26,11 +26,13 @@ class ImportExternalLibrariesPage : public Utils::WizardPage
 {
     Q_OBJECT
     Q_PROPERTY(QString qmlLibrariesImports READ qmlLibrariesImports)
+    Q_PROPERTY(QString qmlLibrariesTypes READ qmlLibrariesTypes)
 
 public:
     explicit ImportExternalLibrariesPage();
 
     QString qmlLibrariesImports() const;
+    QString qmlLibrariesTypes() const;
 
 private:
     Ui::ImportExternalLibrariesPage m_pageUi;

--- a/src/plugins/sailfishoswizards/include/pages/importexternallibrariespage.h
+++ b/src/plugins/sailfishoswizards/include/pages/importexternallibrariespage.h
@@ -1,0 +1,52 @@
+/*
+ * Qt Creator plugin with wizards of the Sailfish OS projects.
+ * Copyright © 2020 FRUCT LLC.
+ */
+
+#ifndef IMPORTEXTERNALLIBRARIESPAGE_H
+#define IMPORTEXTERNALLIBRARIESPAGE_H
+
+#include <utils/wizardpage.h>
+#include <projectexplorer/jsonwizard/jsonwizard.h>
+
+#include "models/externallibrarylistmodel.h"
+#include "ui_importexternallibrariespage.h"
+#include "ui_selectitemsdialog.h"
+
+namespace SailfishOSWizards {
+namespace Internal {
+
+using namespace ProjectExplorer;
+
+/*!
+ * \brief ImportExternalLibrariesPage class is a page to import standard external libraries
+ * for the created project or file.
+ */
+class ImportExternalLibrariesPage : public Utils::WizardPage
+{
+    Q_OBJECT
+    Q_PROPERTY(QString qmlLibrariesImports READ qmlLibrariesImports)
+
+public:
+    explicit ImportExternalLibrariesPage();
+
+    QString qmlLibrariesImports() const;
+
+private:
+    Ui::ImportExternalLibrariesPage m_pageUi;
+    Ui::SelectItemsDialog m_selectLibrariesDialogUi;
+    QDialog m_selectLibrariesDialog;
+    ExternalLibraryListModel *m_allLibraries;
+    ExternalLibraryListModel *m_selectedLibraries;
+
+    void openSelectLibrariesDialog();
+    void removeSelectedLibraryFromList();
+    void addSelectedLibrary(const QModelIndex &index);
+    void addMultimpleSelectedLibraries();
+    void addExternalLibrary(const int index);
+};
+
+}
+}
+
+#endif // IMPORTEXTERNALLIBRARIESPAGE_H

--- a/src/plugins/sailfishoswizards/include/pages/qmllocalimportspage.h
+++ b/src/plugins/sailfishoswizards/include/pages/qmllocalimportspage.h
@@ -1,0 +1,53 @@
+/*
+ * Qt Creator plugin with wizards of the Sailfish OS projects.
+ * Copyright © 2020 FRUCT LLC.
+ */
+
+#ifndef QMLLOCALIMPORTSPAGE_H
+#define QMLLOCALIMPORTSPAGE_H
+
+#include <utils/wizardpage.h>
+#include <projectexplorer/jsonwizard/jsonwizard.h>
+
+#include "ui_qmllocalimportspage.h"
+
+namespace SailfishOSWizards {
+namespace Internal {
+
+using namespace ProjectExplorer;
+
+/*!
+ * brief QmlLocalImportsPage class is a page for adding local imports for the QML-file.
+ * The page is used on the wizard for creating new QML-file.
+ */
+class QmlLocalImportsPage : public Utils::WizardPage
+{
+    Q_OBJECT
+    Q_PROPERTY(QString localImports READ localImports)
+
+public:
+    explicit QmlLocalImportsPage();
+
+    void initializePage() Q_DECL_OVERRIDE;
+
+    QString localImports() const;
+
+private:
+    JsonWizard *m_wizard;
+    QString m_path;
+    QStringList m_importsList;
+    Ui::QmlLocalImportsPage m_pageUi;
+
+    void openFileDialog();
+    void openQmldirDialog();
+    void openDirDialog();
+
+    void addImports(QStringList localImports);
+    void addImport(const QString &import);
+    void removeSelectedImport();
+};
+
+}
+}
+
+#endif // QMLLOCALIMPORTSPAGE_H

--- a/src/plugins/sailfishoswizards/resources.qrc
+++ b/src/plugins/sailfishoswizards/resources.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/sailfishoswizards">
+        <file>data/qml-modules.json</file>
+    </qresource>
+</RCC>

--- a/src/plugins/sailfishoswizards/sailfishoswizards.pro
+++ b/src/plugins/sailfishoswizards/sailfishoswizards.pro
@@ -7,14 +7,29 @@ INCLUDEPATH += include
 SOURCES += \
     sailfishoswizardsplugin.cpp \
     src/pages/qmllocalimportspage.cpp \
-    src/factories/qmllocalimportspagefactory.cpp
+    src/factories/qmllocalimportspagefactory.cpp \
+    src/factories/importexternallibrariespagefactory.cpp \
+    src/pages/importexternallibrariespage.cpp \
+    src/models/externallibrarylistmodel.cpp \
+    src/models/externallibrary.cpp \
+    utils.cpp
 
 HEADERS += \
     sailfishoswizardsplugin.h \
     sailfishoswizards_global.h \
     sailfishoswizardsconstants.h \
     include/pages/qmllocalimportspage.h \
-    include/factories/qmllocalimportspagefactory.h
+    include/factories/qmllocalimportspagefactory.h \
+    include/pages/importexternallibrariespage.h \
+    include/factories/importexternallibrariespagefactory.h \
+    include/models/externallibrarylistmodel.h \
+    include/models/externallibrary.h \
+    utils.h
 
 FORMS += \
-    forms/qmllocalimportspage.ui
+    forms/qmllocalimportspage.ui \
+    forms/importexternallibrariespage.ui \
+    forms/selectitemsdialog.ui
+
+RESOURCES += \
+    resources.qrc

--- a/src/plugins/sailfishoswizards/sailfishoswizards.pro
+++ b/src/plugins/sailfishoswizards/sailfishoswizards.pro
@@ -1,0 +1,20 @@
+include(../../qtcreatorplugin.pri)
+
+DEFINES += SAILFISHOSWIZARDS_LIBRARY
+
+INCLUDEPATH += include
+
+SOURCES += \
+    sailfishoswizardsplugin.cpp \
+    src/pages/qmllocalimportspage.cpp \
+    src/factories/qmllocalimportspagefactory.cpp
+
+HEADERS += \
+    sailfishoswizardsplugin.h \
+    sailfishoswizards_global.h \
+    sailfishoswizardsconstants.h \
+    include/pages/qmllocalimportspage.h \
+    include/factories/qmllocalimportspagefactory.h
+
+FORMS += \
+    forms/qmllocalimportspage.ui

--- a/src/plugins/sailfishoswizards/sailfishoswizards_dependencies.pri
+++ b/src/plugins/sailfishoswizards/sailfishoswizards_dependencies.pri
@@ -1,0 +1,8 @@
+QTC_PLUGIN_NAME = SailfishOSWizards
+
+QTC_LIB_DEPENDS += \
+    utils
+
+QTC_PLUGIN_DEPENDS += \
+    coreplugin \
+    projectexplorer

--- a/src/plugins/sailfishoswizards/sailfishoswizards_dependencies.pri
+++ b/src/plugins/sailfishoswizards/sailfishoswizards_dependencies.pri
@@ -1,7 +1,8 @@
 QTC_PLUGIN_NAME = SailfishOSWizards
 
 QTC_LIB_DEPENDS += \
-    utils
+    utils \
+    sfdk
 
 QTC_PLUGIN_DEPENDS += \
     coreplugin \

--- a/src/plugins/sailfishoswizards/sailfishoswizards_global.h
+++ b/src/plugins/sailfishoswizards/sailfishoswizards_global.h
@@ -1,0 +1,17 @@
+/*
+ * Qt Creator plugin with wizards of the Sailfish OS projects.
+ * Copyright © 2020 FRUCT LLC.
+ */
+
+#ifndef SAILFISHOSWIZARDS_GLOBAL_H
+#define SAILFISHOSWIZARDS_GLOBAL_H
+
+#include <QtGlobal>
+
+#if defined(SAILFISHOSWIZARDS_LIBRARY)
+#  define SAILFISHOSWIZARDSSHARED_EXPORT Q_DECL_EXPORT
+#else
+#  define SAILFISHOSWIZARDSSHARED_EXPORT Q_DECL_IMPORT
+#endif
+
+#endif // SAILFISHOSWIZARDS_GLOBAL_H

--- a/src/plugins/sailfishoswizards/sailfishoswizardsconstants.h
+++ b/src/plugins/sailfishoswizards/sailfishoswizardsconstants.h
@@ -1,0 +1,15 @@
+/*
+ * Qt Creator plugin with wizards of the Sailfish OS projects.
+ * Copyright © 2020 FRUCT LLC.
+ */
+
+#ifndef SAILFISHOSWIZARDS_CONSTANTS_H
+#define SAILFISHOSWIZARDS_CONSTANTS_H
+
+namespace SailfishOSWizards {
+namespace Constants {
+
+} // namespace SailfishOSWizards
+} // namespace Constants
+
+#endif // SAILFISHOSWIZARDS_CONSTANTS_H

--- a/src/plugins/sailfishoswizards/sailfishoswizardsplugin.cpp
+++ b/src/plugins/sailfishoswizards/sailfishoswizardsplugin.cpp
@@ -9,6 +9,7 @@
 #include <projectexplorer/jsonwizard/jsonwizardfactory.h>
 
 #include "factories/qmllocalimportspagefactory.h"
+#include "factories/importexternallibrariespagefactory.h"
 
 namespace SailfishOSWizards {
 namespace Internal {
@@ -30,6 +31,7 @@ bool SailfishOSWizardsPlugin::initialize(const QStringList &arguments, QString *
     Q_UNUSED(arguments)
     Q_UNUSED(errorString)
     JsonWizardFactory::registerPageFactory(new QmlLocalImportsPageFactory);
+    JsonWizardFactory::registerPageFactory(new ImportExternalLibrariesPageFactory);
     return true;
 }
 

--- a/src/plugins/sailfishoswizards/sailfishoswizardsplugin.cpp
+++ b/src/plugins/sailfishoswizards/sailfishoswizardsplugin.cpp
@@ -7,6 +7,7 @@
 #include "sailfishoswizardsconstants.h"
 
 #include <projectexplorer/jsonwizard/jsonwizardfactory.h>
+#include <sfdk/sdk.h>
 
 #include "factories/qmllocalimportspagefactory.h"
 #include "factories/importexternallibrariespagefactory.h"
@@ -30,6 +31,9 @@ bool SailfishOSWizardsPlugin::initialize(const QStringList &arguments, QString *
 {
     Q_UNUSED(arguments)
     Q_UNUSED(errorString)
+    Utils::globalMacroExpander()->registerVariable("SailfishOSFileWizardCategoryName",
+                                                   tr("Category of a wizard for Sailfish OS files"),
+                                                   []() { return Sfdk::Sdk::osVariant(); });
     JsonWizardFactory::registerPageFactory(new QmlLocalImportsPageFactory);
     JsonWizardFactory::registerPageFactory(new ImportExternalLibrariesPageFactory);
     return true;

--- a/src/plugins/sailfishoswizards/sailfishoswizardsplugin.cpp
+++ b/src/plugins/sailfishoswizards/sailfishoswizardsplugin.cpp
@@ -1,0 +1,46 @@
+/*
+ * Qt Creator plugin with wizards of the Sailfish OS projects.
+ * Copyright © 2020 FRUCT LLC.
+ */
+
+#include "sailfishoswizardsplugin.h"
+#include "sailfishoswizardsconstants.h"
+
+#include <projectexplorer/jsonwizard/jsonwizardfactory.h>
+
+#include "factories/qmllocalimportspagefactory.h"
+
+namespace SailfishOSWizards {
+namespace Internal {
+
+SailfishOSWizardsPlugin::SailfishOSWizardsPlugin()
+{
+}
+
+SailfishOSWizardsPlugin::~SailfishOSWizardsPlugin()
+{
+}
+
+/*!
+ * \brief Initializes the plugin.
+ * This method registers the pages factories for using the pages inside the JSON-based wizards.
+ */
+bool SailfishOSWizardsPlugin::initialize(const QStringList &arguments, QString *errorString)
+{
+    Q_UNUSED(arguments)
+    Q_UNUSED(errorString)
+    JsonWizardFactory::registerPageFactory(new QmlLocalImportsPageFactory);
+    return true;
+}
+
+void SailfishOSWizardsPlugin::extensionsInitialized()
+{
+}
+
+ExtensionSystem::IPlugin::ShutdownFlag SailfishOSWizardsPlugin::aboutToShutdown()
+{
+    return SynchronousShutdown;
+}
+
+} // namespace Internal
+} // namespace SailfishOSWizardFields

--- a/src/plugins/sailfishoswizards/sailfishoswizardsplugin.h
+++ b/src/plugins/sailfishoswizards/sailfishoswizardsplugin.h
@@ -1,0 +1,37 @@
+/*
+ * Qt Creator plugin with wizards of the Sailfish OS projects.
+ * Copyright © 2020 FRUCT LLC.
+ */
+
+#ifndef SAILFISHOSWIZARDS_H
+#define SAILFISHOSWIZARDS_H
+
+#include "sailfishoswizards_global.h"
+
+#include <extensionsystem/iplugin.h>
+
+namespace SailfishOSWizards {
+namespace Internal {
+
+/*!
+ * \brief SailfishOSWizardsPlugin class is a plugin that registers new pages types
+ * for JSON-based wizards.
+ */
+class SailfishOSWizardsPlugin : public ExtensionSystem::IPlugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.qt-project.Qt.QtCreatorPlugin" FILE "SailfishOSWizards.json")
+
+public:
+    SailfishOSWizardsPlugin();
+    ~SailfishOSWizardsPlugin() Q_DECL_OVERRIDE;
+
+    bool initialize(const QStringList &arguments, QString *errorString) Q_DECL_OVERRIDE;
+    void extensionsInitialized() Q_DECL_OVERRIDE;
+    ShutdownFlag aboutToShutdown() Q_DECL_OVERRIDE;
+};
+
+} // namespace Internal
+} // namespace SailfishOSWizards
+
+#endif // SAILFISHOSWIZARDS_H

--- a/src/plugins/sailfishoswizards/src/factories/importexternallibrariespagefactory.cpp
+++ b/src/plugins/sailfishoswizards/src/factories/importexternallibrariespagefactory.cpp
@@ -1,0 +1,44 @@
+/*
+ * Qt Creator plugin with wizards of the Sailfish OS projects.
+ * Copyright © 2020 FRUCT LLC.
+ */
+
+#include "factories/importexternallibrariespagefactory.h"
+
+#include <projectexplorer/jsonwizard/jsonwizardfactory.h>
+#include <utils/qtcassert.h>
+
+#include "pages/importexternallibrariespage.h"
+
+namespace SailfishOSWizards {
+namespace Internal {
+
+ImportExternalLibrariesPageFactory::ImportExternalLibrariesPageFactory()
+{
+    setTypeIdsSuffix(QLatin1String("ImportExternalLibraries"));
+}
+
+Utils::WizardPage *ImportExternalLibrariesPageFactory::create(ProjectExplorer::JsonWizard *wizard,
+                                                              Core::Id typeId, const QVariant &data)
+{
+    Q_UNUSED(wizard)
+    Q_UNUSED(data)
+    QTC_ASSERT(canCreate(typeId), return nullptr);
+    return new ImportExternalLibrariesPage;
+}
+
+bool ImportExternalLibrariesPageFactory::validateData(Core::Id typeId, const QVariant &data,
+                                                      QString *errorMessage)
+{
+    QTC_ASSERT(canCreate(typeId), return false);
+    if (!data.isNull() && (data.type() != QVariant::Map || !data.toMap().isEmpty())) {
+        *errorMessage = QCoreApplication::translate(
+                            "ProjectExplorer::JsonWizard",
+                            "\"data\" for a \"ImportExternalLibraries\" page needs to be unset or an empty object.");
+        return false;
+    }
+    return true;
+}
+
+}
+}

--- a/src/plugins/sailfishoswizards/src/factories/qmllocalimportspagefactory.cpp
+++ b/src/plugins/sailfishoswizards/src/factories/qmllocalimportspagefactory.cpp
@@ -1,0 +1,44 @@
+/*
+ * Qt Creator plugin with wizards of the Sailfish OS projects.
+ * Copyright © 2020 FRUCT LLC.
+ */
+
+#include "factories/qmllocalimportspagefactory.h"
+
+#include <projectexplorer/jsonwizard/jsonwizardfactory.h>
+#include <utils/qtcassert.h>
+
+#include "pages/qmllocalimportspage.h"
+
+namespace SailfishOSWizards {
+namespace Internal {
+
+QmlLocalImportsPageFactory::QmlLocalImportsPageFactory()
+{
+    setTypeIdsSuffix(QLatin1String("QmlLocalImports"));
+}
+
+Utils::WizardPage *QmlLocalImportsPageFactory::create(JsonWizard *wizard, Core::Id typeId,
+                                                      const QVariant &data)
+{
+    Q_UNUSED(wizard)
+    Q_UNUSED(data)
+    QTC_ASSERT(canCreate(typeId), return nullptr);
+    return new QmlLocalImportsPage;
+}
+
+bool QmlLocalImportsPageFactory::validateData(Core::Id typeId, const QVariant &data,
+                                              QString *errorMessage)
+{
+    QTC_ASSERT(canCreate(typeId), return false);
+    if (!data.isNull() && (data.type() != QVariant::Map || !data.toMap().isEmpty())) {
+        *errorMessage = QCoreApplication::translate(
+                    "ProjectExplorer::JsonWizard",
+                    "\"data\" for a \"QmlLocalImports\" page needs to be unset or an empty object.");
+        return false;
+    }
+    return true;
+}
+
+}
+}

--- a/src/plugins/sailfishoswizards/src/models/externallibrary.cpp
+++ b/src/plugins/sailfishoswizards/src/models/externallibrary.cpp
@@ -1,0 +1,149 @@
+/*
+ * Qt Creator plugin with wizards of the Sailfish OS projects.
+ * Copyright © 2020 FRUCT LLC.
+ */
+
+#include "models/externallibrary.h"
+
+namespace SailfishOSWizards {
+namespace Internal {
+
+/*!
+ * \brief Sets the name for the external library.
+ * \param name New name.
+ */
+void ExternalLibrary::setName(const QString &name)
+{
+    m_name = name;
+}
+
+/*!
+ * \brief Sets the visible name for the external library.
+ * \param layoutName New layout name.
+ */
+void ExternalLibrary::setLayoutName(const QString &layoutName)
+{
+    m_layoutName = layoutName;
+}
+
+/*!
+ * \brief Sets the connection list for a .pro-file
+ * \param qtList New list.
+ */
+void ExternalLibrary::setQtList(QStringList qtList)
+{
+    m_qtList = qtList;
+}
+
+/*!
+ * \brief Sets the list of dependencies.
+ * \param dependencyList New dependecy list.
+ */
+void ExternalLibrary::setDependencyList(QStringList dependencyList)
+{
+    m_dependencyList = dependencyList;
+}
+
+/*!
+ * \brief Sets the list of basic types.
+ * \param types New types.
+ */
+void ExternalLibrary::setTypesList(QStringList types)
+{
+    m_types = types;
+}
+
+/*!
+ * \brief Sets heading for yaml dependencies.
+ * \param yamlHeader Heading for yaml dependencies.
+ */
+void ExternalLibrary::setYamlHeader(const QString &yamlHeader)
+{
+    m_yamlHeader = yamlHeader;
+}
+
+/*!
+ * \brief Sets heading for spec dependencies.
+ * \param specHeader Heading for spec dependencies.
+ */
+void ExternalLibrary::setSpecHeader(const QString &specHeader)
+{
+    m_specHeader = specHeader;
+}
+
+/*!
+ * \brief Returns name.
+ */
+QString ExternalLibrary::getName() const
+{
+    return m_name;
+}
+
+/*!
+ * \brief Returns the name to display.
+ */
+QString ExternalLibrary::getLayoutName() const
+{
+    return m_layoutName;
+}
+
+/*!
+ * \brief Returns a list of dependencies for a .pro-file.
+ */
+QStringList ExternalLibrary::getQtList() const
+{
+    return m_qtList;
+}
+
+/*!
+ * \brief Returns a list of dependencies.
+ */
+QStringList ExternalLibrary::getDependencyList() const
+{
+    return m_dependencyList;
+}
+
+/*!
+ * \brief Returns list Returns a list of basic types.
+ */
+QStringList ExternalLibrary::getTypesList() const
+{
+    return m_types;
+}
+
+/*!
+ * \brief Returns the yaml header.
+ */
+QString ExternalLibrary::getYamlHeader() const
+{
+    return m_yamlHeader;
+}
+
+/*!
+ * \brief Returns the spec header.
+ */
+QString ExternalLibrary::getSpecHeader() const
+{
+    return m_specHeader;
+}
+
+/*!
+ * \brief Removes the dependency list entry for the .pro file.
+ * \param index Item index.
+ */
+void ExternalLibrary::removeQtListItem(const int index)
+{
+    m_qtList.removeAt(index);
+}
+
+/*!
+ * \brief Removes the dependency list.
+ * \param index Item index.
+ */
+void ExternalLibrary::removeDependencyListItem(const int index)
+{
+    m_dependencyList.removeAt(index);
+}
+
+}
+}

--- a/src/plugins/sailfishoswizards/src/models/externallibrarylistmodel.cpp
+++ b/src/plugins/sailfishoswizards/src/models/externallibrarylistmodel.cpp
@@ -1,0 +1,119 @@
+/*
+ * Qt Creator plugin with wizards of the Sailfish OS projects.
+ * Copyright © 2020 FRUCT LLC.
+ */
+
+#include "models/externallibrarylistmodel.h"
+
+namespace SailfishOSWizards {
+namespace Internal {
+
+/*!
+ * \brief Constructor initializes a list of model roles.
+ * \param parent Parent object instance.
+ */
+ExternalLibraryListModel::ExternalLibraryListModel(QObject *parent) : QAbstractListModel(parent),
+    m_roles{{LayoutName, "layoutName"}, {Name, "name"}, {QtList, "qt"}, {YamlHeader, "yamlHeader"},
+    {SpecHeader, "specHeader"}, {DependencyList, "dependencies"}, {Types, "types"}}
+{
+}
+
+/*!
+ * \brief Returns a field of the external library by the specified role.
+ * \param index Index to retrieve the external library data.
+ * \param role Role number.
+ * \return Exteranl library data.
+ */
+QVariant ExternalLibraryListModel::data(const QModelIndex &index, int role) const
+{
+    if (index.row() < 0 || index.row() > m_externalLibraries.count())
+        return QVariant();
+    ExternalLibrary externalLibrary = m_externalLibraries[index.row()];
+    if (role == LayoutName) {
+        return externalLibrary.getLayoutName();
+    } else if (role == Name) {
+        return externalLibrary.getName();
+    } else if (role == QtList) {
+        return externalLibrary.getQtList();
+    } else if (role == YamlHeader) {
+        return externalLibrary.getYamlHeader();
+    } else if (role == SpecHeader) {
+        return externalLibrary.getSpecHeader();
+    } else if (role == DependencyList) {
+        return externalLibrary.getDependencyList();
+    } else if (role == Types) {
+        return externalLibrary.getTypesList();
+    }
+    return QVariant();
+}
+
+/*!
+ * \brief Returns the number of rows of the model.
+ * \param parent The parent object instance.
+ */
+int ExternalLibraryListModel::rowCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent)
+    return m_externalLibraries.size();
+}
+
+/*!
+ * \brief Deletes selected rows from the list model.
+ * \param pos Start row number to remove.
+ * \param count Count of rows to remove.
+ * \param parent Parent object instance.
+ * \return True if operation is done successfully, false — if not.
+ */
+bool ExternalLibraryListModel::removeRows(int pos, int count, const QModelIndex &parent)
+{
+    Q_UNUSED(parent)
+    beginRemoveRows(QModelIndex(), pos, pos + count - 1);
+    for (int row = 0; row < count; row++) {
+        m_externalLibraries.removeAt(pos);
+    }
+    endRemoveRows();
+    return true;
+}
+
+/*!
+ * \return Number of model elements.
+ */
+int ExternalLibraryListModel::size() const
+{
+    return m_externalLibraries.size();
+}
+
+/*!
+ * \brief Clears the model.
+ */
+void ExternalLibraryListModel::clear()
+{
+    m_externalLibraries.clear();
+}
+
+/*!
+ * \brief Retrieves the external library model item.
+ * \param index Item index to retrieve.
+ * \return ExternalLibrary class instance.
+ */
+ExternalLibrary ExternalLibraryListModel::getExternalLibrary(const int index) const
+{
+    if (index < 0 || index > m_externalLibraries.count()) {
+        return m_externalLibraries[0];
+    } else {
+        return  m_externalLibraries[index];
+    }
+}
+
+/*!
+ * \brief Adds a new external library to the list model.
+ * \param externalLibrary ExternalLibrary class instance to add.
+ */
+void ExternalLibraryListModel::addExternalLibrary(ExternalLibrary externalLibrary)
+{
+    m_externalLibraries << externalLibrary;
+    emit dataChanged(createIndex(0, 0), createIndex(m_externalLibraries.size() - 1, 0));
+}
+
+}
+}

--- a/src/plugins/sailfishoswizards/src/pages/importexternallibrariespage.cpp
+++ b/src/plugins/sailfishoswizards/src/pages/importexternallibrariespage.cpp
@@ -1,0 +1,113 @@
+/*
+ * Qt Creator plugin with wizards of the Sailfish OS projects.
+ * Copyright © 2020 FRUCT LLC.
+ */
+
+#include "pages/importexternallibrariespage.h"
+
+#include "sailfishoswizards/utils.h"
+
+namespace SailfishOSWizards {
+namespace Internal {
+
+/*!
+ * \brief Constructor initializes the class fields, loads  descriptions of the external libraries
+ * available to import and sets up connections for the page and dialog buttons.
+ */
+ImportExternalLibrariesPage::ImportExternalLibrariesPage()
+    : m_selectedLibraries(new ExternalLibraryListModel)
+{
+    m_pageUi.setupUi(this);
+    m_selectLibrariesDialogUi.setupUi(&m_selectLibrariesDialog);
+    m_allLibraries = Utils::loadExternalLibraries(":/sailfishoswizards/data/qml-modules.json");
+    m_selectLibrariesDialogUi.itemList->setModel(m_allLibraries);
+    m_pageUi.libraryList->setModel(m_selectedLibraries);
+    connect(m_pageUi.addButton, &QPushButton::clicked,
+            this, &ImportExternalLibrariesPage::openSelectLibrariesDialog);
+    connect(m_pageUi.removeButton, &QPushButton::clicked,
+            this, &ImportExternalLibrariesPage::removeSelectedLibraryFromList);
+    connect(m_selectLibrariesDialogUi.cancelButton, &QPushButton::clicked,
+            &m_selectLibrariesDialog, &QDialog::close);
+    connect(m_selectLibrariesDialogUi.itemList, &QListView::doubleClicked,
+            this, &ImportExternalLibrariesPage::addSelectedLibrary);
+    connect(m_selectLibrariesDialogUi.addButton, &QPushButton::clicked,
+            this, &ImportExternalLibrariesPage::addMultimpleSelectedLibraries);
+    registerFieldWithName(QLatin1String("QmlLibrariesImports"), this, "qmlLibrariesImports");
+}
+
+/*!
+ * \brief Creates and returns a string with list of imports for the new QML-file.
+ * Resulting string contains list of substrings in format 'import <lib-name-with-version>\n'.
+ * \return String with imports for the QML-file.
+ */
+QString ImportExternalLibrariesPage::qmlLibrariesImports() const
+{
+    QString importsString;
+    for (int i = 0; i < m_selectedLibraries->size(); i++) {
+        QString import = m_selectedLibraries->index(i, 0).data(ExternalLibraryListModel::Name).toString();
+        importsString.append(QString("import %1\n").arg(import));
+    }
+    return importsString;
+}
+
+/*!
+ * \brief Opens a dialog to select external libraries.
+ */
+void ImportExternalLibrariesPage::openSelectLibrariesDialog()
+{
+    m_selectLibrariesDialog.exec();
+}
+
+/*!
+ * \brief Removes the selected library from the selected list.
+ */
+void ImportExternalLibrariesPage::removeSelectedLibraryFromList()
+{
+    int index = m_pageUi.libraryList->currentIndex().row();
+    if (index < 0 || index > m_selectedLibraries->size())
+        return;
+    ExternalLibrary newExternalLibrary = m_selectedLibraries->getExternalLibrary(index);
+    m_allLibraries->addExternalLibrary(newExternalLibrary);
+    m_selectedLibraries->removeRows(index, 1);
+}
+
+/*!
+ * \brief Adds the selected library from the 'All libraries' list by its QModelIndex item.
+ * \param index QModelIndex instance.
+ */
+void ImportExternalLibrariesPage::addSelectedLibrary(const QModelIndex &index)
+{
+    addExternalLibrary(index.row());
+    m_allLibraries->removeRows(index.row(), 1);
+    m_selectLibrariesDialog.close();
+}
+
+/*!
+ * \brief Adds the multiple selected libraries from the 'All libraries' to the list of selected.
+ */
+void ImportExternalLibrariesPage::addMultimpleSelectedLibraries()
+{
+    QModelIndexList indexes = m_selectLibrariesDialogUi.itemList->selectionModel()->selectedIndexes();
+    std::sort(indexes.begin(), indexes.end());
+    for (QModelIndex index : indexes) {
+        addExternalLibrary(index.row());
+    }
+    for (int i = indexes.count() - 1; i >= 0; i--) {
+        m_allLibraries->removeRows(indexes.value(i).row(), 1);
+    }
+    m_selectLibrariesDialog.close();
+}
+
+/*!
+ * \brief Adds the library to the list of selected by its index.
+ * \param index Integer value with index of library inside 'All libraries' list.
+ */
+void ImportExternalLibrariesPage::addExternalLibrary(const int index)
+{
+    if (index < 0 || index > m_allLibraries->size())
+        return;
+    m_selectedLibraries->addExternalLibrary(m_allLibraries->getExternalLibrary(index));
+}
+
+}
+}

--- a/src/plugins/sailfishoswizards/src/pages/importexternallibrariespage.cpp
+++ b/src/plugins/sailfishoswizards/src/pages/importexternallibrariespage.cpp
@@ -7,6 +7,9 @@
 
 #include "sailfishoswizards/utils.h"
 
+#include <QJsonDocument>
+#include <QJsonArray>
+
 namespace SailfishOSWizards {
 namespace Internal {
 
@@ -33,6 +36,7 @@ ImportExternalLibrariesPage::ImportExternalLibrariesPage()
     connect(m_selectLibrariesDialogUi.addButton, &QPushButton::clicked,
             this, &ImportExternalLibrariesPage::addMultimpleSelectedLibraries);
     registerFieldWithName(QLatin1String("QmlLibrariesImports"), this, "qmlLibrariesImports");
+    registerFieldWithName(QLatin1String("QmlLibrariesTypes"), this, "qmlLibrariesTypes");
 }
 
 /*!
@@ -48,6 +52,22 @@ QString ImportExternalLibrariesPage::qmlLibrariesImports() const
         importsString.append(QString("import %1\n").arg(import));
     }
     return importsString;
+}
+
+/*!
+ * \brief Creates and returns a string with QML-types from selected external libraries.
+ * \return QString with names of types that can be used as parent for new QML-type
+ * in the JSON-array format.
+ */
+QString ImportExternalLibrariesPage::qmlLibrariesTypes() const
+{
+    QStringList types = QStringList() << "Item";
+    for (int i = 0; i < m_selectedLibraries->size(); i++) {
+        types << m_selectedLibraries->index(i, 0).data(ExternalLibraryListModel::Types).toStringList();
+    }
+    QJsonDocument doc;
+    doc.setArray(QJsonArray::fromStringList(types));
+    return QString::fromUtf8(doc.toJson());
 }
 
 /*!

--- a/src/plugins/sailfishoswizards/src/pages/qmllocalimportspage.cpp
+++ b/src/plugins/sailfishoswizards/src/pages/qmllocalimportspage.cpp
@@ -1,0 +1,121 @@
+/*
+ * Qt Creator plugin with wizards of the Sailfish OS projects.
+ * Copyright © 2020 FRUCT LLC.
+ */
+
+#include "pages/qmllocalimportspage.h"
+
+#include <QFileDialog>
+#include <QMessageBox>
+
+namespace SailfishOSWizards {
+namespace Internal {
+
+/*!
+ * \brief Constructor for the local import page, sets up the page interface connections for buttons
+ * to add and remove imports and registers a the 'LocalImports' field to use it inside
+ * the QML-file template.
+ */
+QmlLocalImportsPage::QmlLocalImportsPage()
+{
+    m_pageUi.setupUi(this);
+    QObject::connect(m_pageUi.addFileButton, &QPushButton::clicked,
+                     this, &QmlLocalImportsPage::openFileDialog);
+    QObject::connect(m_pageUi.removeButton, &QPushButton::clicked,
+                     this, &QmlLocalImportsPage::removeSelectedImport);
+    QObject::connect(m_pageUi.addDirButton, &QPushButton::clicked,
+                     this, &QmlLocalImportsPage::openDirDialog);
+    registerFieldWithName(QLatin1String("LocalImports"), this, "localImports");
+}
+
+/*!
+ * \brief Initializes a target path to create QML file by retrieving the 'Path' value
+ * from the wizard.
+ */
+void QmlLocalImportsPage::initializePage()
+{
+    m_wizard = qobject_cast<JsonWizard *>(wizard());
+    m_path = m_wizard->stringValue(QLatin1String("Path"));
+}
+
+/*!
+ * \brief Opens a dialog for the user to add js-files to the list of local imports.
+ */
+void QmlLocalImportsPage::openFileDialog()
+{
+    QStringList chosenFiles = QFileDialog::getOpenFileNames(
+                            this, tr("Select one or more JavaScript files to import"),
+                            m_path, tr("JavaScript files (*.js)"));
+    if (!chosenFiles.isEmpty()) {
+        addImports(chosenFiles);
+    }
+}
+
+/*!
+ * \brief Opens a dialog for the user to add directories to the list of local imports.
+ */
+void QmlLocalImportsPage::openDirDialog()
+{
+    QString chosenPath = QFileDialog::getExistingDirectory(
+                this, tr("Select directory containing QML files to import"), m_path);
+    if (chosenPath.compare(m_path) == 0) {
+        QMessageBox message;
+        message.setText(tr("You do not need to add the target directory to local imports, "
+                           "because it is included by default."));
+        message.setIcon(QMessageBox::Icon::Information);
+        message.exec();
+    } else if (!chosenPath.isEmpty()) {
+        addImport(chosenPath);
+    }
+}
+
+/*!
+ * \brief Adds the given list of new imports to the list of already added imports.
+ * \param imports List of imports to add.
+ */
+void QmlLocalImportsPage::addImports(QStringList imports)
+{
+    for (QString import : imports) {
+        QString relativePath = QDir(m_path).relativeFilePath(import);
+        if (!m_importsList.contains(relativePath))
+            m_importsList.append(relativePath);
+    }
+    m_importsList.sort();
+    m_pageUi.listImports->clear();
+    m_pageUi.listImports->addItems(m_importsList);
+}
+
+/*!
+ * \brief Adds a new import to the list of already added imports.
+ * \param import New import to add.
+ */
+void QmlLocalImportsPage::addImport(const QString &import)
+{
+    addImports(QStringList() << import);
+}
+
+/*!
+ * \brief Deletes the current selected local import.
+ */
+void QmlLocalImportsPage::removeSelectedImport()
+{
+    m_importsList.removeAt(m_pageUi.listImports->currentRow());
+    m_pageUi.listImports->takeItem(m_pageUi.listImports->currentRow());
+}
+
+/*!
+ * Creates and returns a string with list of imports for the new QML-file.
+ * Resulting string contains list of substrings in format 'import <path>\n'.
+ * \return String with imports for the QML-file.
+ */
+QString QmlLocalImportsPage::localImports() const
+{
+    QString localImportsString;
+    for (QString import : m_importsList) {
+        localImportsString.append(QString("import \"%1\"\n").arg(import));
+    }
+    return localImportsString;
+}
+
+}
+}

--- a/src/plugins/sailfishoswizards/utils.cpp
+++ b/src/plugins/sailfishoswizards/utils.cpp
@@ -1,0 +1,77 @@
+/*
+ * Qt Creator plugin with wizards of the Sailfish OS projects.
+ * Copyright © 2020 FRUCT LLC.
+ */
+
+#include "utils.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QFile>
+#include <QTextCodec>
+
+namespace SailfishOSWizards {
+namespace Internal {
+
+/*!
+ * \brief Reads a JSON_file with description of external libraries, writes the read data into
+ * the ExternalLibraryListModel instance and return the instance pointer.
+ * \param modulesJsonFilePath Path to the JSON-file with description of external libraries.
+ * \return ExternalLibraryListModel instance pointer.
+ */
+ExternalLibraryListModel *Utils::loadExternalLibraries(const QString &modulesJsonFilePath)
+{
+    ExternalLibraryListModel *model = new ExternalLibraryListModel;
+    ExternalLibrary newExternalLibrary;
+    QString jsonFileString = readFile(modulesJsonFilePath);
+    QJsonObject jsonObject = QJsonDocument::fromJson(jsonFileString.toUtf8()).object();
+    for (QJsonObject::Iterator iter = jsonObject.begin(); iter != jsonObject.end(); ++iter) {
+        newExternalLibrary.setName(iter.key());
+        QJsonObject obj = iter.value().toObject();
+        newExternalLibrary.setLayoutName(obj["layoutname"].toString());
+        newExternalLibrary.setQtList(jsonArrayToStringList(obj["qt"].toArray()));
+        newExternalLibrary.setYamlHeader(obj["yamlheader"].toString());
+        newExternalLibrary.setSpecHeader(obj["specheader"].toString());
+        newExternalLibrary.setDependencyList(jsonArrayToStringList(obj["dependencies"].toArray(),
+                                                                   QRegExp(" ")));
+        newExternalLibrary.setTypesList(jsonArrayToStringList(obj["types"].toArray()));
+        model->addExternalLibrary(newExternalLibrary);
+    }
+    return model;
+}
+
+/*!
+ * \brief Reads a file by the given path and returns its content.
+ * \param filePath Path of file to read.
+ * \return QString with file content.
+ */
+QString Utils::readFile(const QString &filePath)
+{
+    QFile file(filePath);
+    file.open(QIODevice::ReadOnly | QIODevice::Text);
+    QString fileContent = QTextCodec::codecForName("UTF-8")->toUnicode(file.readAll());
+    file.close();
+    return fileContent;
+}
+
+/*!
+ * \brief Converts the given QJsonArray to QStringList.
+ * \param jsonArray QJsonArray object.
+ * \param regExp QRegExp object used if it is needed to split JSON strings by regular expression.
+ * \return QStringList with strings of JSON data.
+ */
+QStringList Utils::jsonArrayToStringList(QJsonArray jsonArray, QRegExp regExp)
+{
+    QStringList strList;
+    for (int i = 0; i < jsonArray.count(); i++) {
+        QString str = jsonArray[i].toString();
+        if (!regExp.isEmpty())
+            str = str.split(regExp).value(0);
+        strList << str;
+    }
+    return strList;
+}
+
+}
+}

--- a/src/plugins/sailfishoswizards/utils.h
+++ b/src/plugins/sailfishoswizards/utils.h
@@ -1,0 +1,31 @@
+/*
+ * Qt Creator plugin with wizards of the Sailfish OS projects.
+ * Copyright © 2020 FRUCT LLC.
+ */
+
+#ifndef UTILS_H
+#define UTILS_H
+
+#include "models/externallibrarylistmodel.h"
+
+namespace SailfishOSWizards {
+namespace Internal {
+
+/*!
+ * \brief Utils class is a class with utility static functions.
+ */
+class Utils
+{
+
+public:
+    static ExternalLibraryListModel *loadExternalLibraries(const QString &modulesJsonFilePath);
+
+private:
+    static QString readFile(const QString &filePath);
+    static QStringList jsonArrayToStringList(QJsonArray jsonArray, QRegExp regExp = QRegExp());
+};
+
+}
+}
+
+#endif // UTILS_H


### PR DESCRIPTION
We implemented the JSON-based wizard to create the QML-files for the Sailfish OS projects. 

This wizard allows to:

1. Set up file name.
2. Add imports with local files and directories to the QML-file.
3. Add imports with external libraries (Qt Positioning and Qt Sensors) to the QML-file.
4. Set up the root QML-type for the file: `Item` or one of imported (like `PositionSource` from Qt Positioning or `Sensor` from Qt Sensors).

Pages for adding local and libraries imports are custom pages with buttons, dialogs and list widgets. To implement the pages we developed a separate Qt Creator plugin with name `SailfishOSWizards` that initializes and registers new pages with their types ids to use them inside `wizard.json`. 

Also we edit the `ComboBoxField` class. By default `ComboBoxField` does not allow to set list of items as a string, only as the JSON array. So, the field does not allow to pass the wizard variable to the `items` field. 

For example, following code is not working:


```json
{
    "name": "QmlBaseType",
    "trDisplayName": "Base type of QML document:",
    "type": "ComboBox",
    "data":
    {
           "items": "%{QmlLibrariesTypes}"
    }
}
```


Variable `QmlLibrariesTypes` containt list of QML-types in depend on the imported libraries and "%{QmlLibrariesTypes}" is a string for the `items` field. So, default `ComboBoxField` cannot be initialized in this case and whole wizard cannot be created also.

This is a reason why we customize `ComboBoxField` to use a string value as the `items` field.