### PR TITLE
Allow to set up JSON-based wizard information with variables

### DIFF
--- a/src/libs/sfdk/asynchronous.cpp
+++ b/src/libs/sfdk/asynchronous.cpp
@@ -26,6 +26,7 @@
 #include <utils/qtcassert.h>
 
 #include <QTimer>
+#include <QTimerEvent>
 
 namespace Sfdk {
 

--- a/src/libs/sfdk/emulator.cpp
+++ b/src/libs/sfdk/emulator.cpp
@@ -38,6 +38,8 @@
 #include <utils/stringutils.h>
 
 #include <QTimer>
+#include <QPoint>
+#include <QRect>
 
 using namespace QSsh;
 using namespace Utils;

--- a/src/plugins/mer/merplugin.cpp
+++ b/src/plugins/mer/merplugin.cpp
@@ -154,6 +154,16 @@ bool MerPlugin::initialize(const QStringList &arguments, QString *errorString)
     RunControl::registerWorker<RemoteLinuxQmlProfilerSupport>(QML_PROFILER_RUN_MODE, constraint);
     //RunControl::registerWorker<RemoteLinuxPerfSupport>(PERFPROFILER_RUN_MODE, constraint);
 
+    Utils::globalMacroExpander()->registerVariable("SailfishOSVariant",
+                                                   tr("Expands to \"Sailfish OS\" or its variant name").arg(Sdk::osVariant()),
+                                                   []() { return Sdk::osVariant(); });
+    Utils::globalMacroExpander()->registerVariable("SailfishIDEVariant",
+                                                   tr("Expands to \"Sailfish IDE\" or its variant name").arg(Sdk::ideVariant()),
+                                                   []() { return Sdk::ideVariant(); });
+    Utils::globalMacroExpander()->registerVariable("SailfishSDKVariant",
+                                                   tr("Expands to \"Sailfish SDK\" or its variant name").arg(Sdk::sdkVariant()),
+                                                   []() { return Sdk::sdkVariant(); });
+
     VirtualMachine::registerConnectionUi<MerVmConnectionUi>();
 
     dd = new MerPluginPrivate;

--- a/src/plugins/mer/merqtversion.h
+++ b/src/plugins/mer/merqtversion.h
@@ -26,6 +26,8 @@
 
 #include <qtsupport/baseqtversion.h>
 
+#include <QUrl>
+
 namespace Mer {
 namespace Internal {
 

--- a/src/plugins/mer/mertoolchain.h
+++ b/src/plugins/mer/mertoolchain.h
@@ -29,6 +29,8 @@
 #include <projectexplorer/gcctoolchain.h>
 #include <projectexplorer/headerpath.h>
 
+#include <QUrl>
+
 namespace Mer {
 namespace Internal {
 

--- a/src/plugins/projectexplorer/jsonwizard/jsonwizardfactory.cpp
+++ b/src/plugins/projectexplorer/jsonwizard/jsonwizardfactory.cpp
@@ -604,21 +604,21 @@ bool JsonWizardFactory::initialize(const QVariantMap &data, const QDir &baseDir,
         *errorMessage = tr("No displayName set.");
         return false;
     }
-    setDisplayName(strVal);
+    setDisplayName(Utils::globalMacroExpander()->expand(strVal));
 
     strVal = localizedString(data.value(QLatin1String(CATEGORY_NAME_KEY)));
     if (strVal.isEmpty()) {
         *errorMessage = tr("No displayCategory set.");
         return false;
     }
-    setDisplayCategory(strVal);
+    setDisplayCategory(Utils::globalMacroExpander()->expand(strVal));
 
     strVal = localizedString(data.value(QLatin1String(DESCRIPTION_KEY)));
     if (strVal.isEmpty()) {
         *errorMessage = tr("No description set.");
         return false;
     }
-    setDescription(strVal);
+    setDescription(Utils::globalMacroExpander()->expand(strVal));
 
     // Generator:
     QVariantList list = objectOrList(data.value(QLatin1String(GENERATOR_KEY)), errorMessage);


### PR DESCRIPTION
This pull request adds possibility to set up the JSON-based wizard information like `displayName`, `displayCategory` and `description` with variables like `"%{VariableName}"`. 

