### PR TITLE
ProjectExplorer: Add the export macros to the JsonSummaryPage declaration

### DIFF
--- a/src/plugins/projectexplorer/jsonwizard/jsonsummarypage.h
+++ b/src/plugins/projectexplorer/jsonwizard/jsonsummarypage.h
@@ -36,7 +36,7 @@ class FolderNode;
 class Node;
 
 // Documentation inside.
-class JsonSummaryPage : public Internal::ProjectWizardPage
+class PROJECTEXPLORER_EXPORT JsonSummaryPage : public Internal::ProjectWizardPage
 {
     Q_OBJECT
 


### PR DESCRIPTION
This pull request adds the `PROJECTEXPLORER_EXPORT` macros to the `JsonSummaryPage` class declaration.

We implement the JSON-based wizards for creating different files for Sailfish OS projects. For example, there is a wizard for creating QML-file with possibility to import external libraries like Qt Sensors and Qt Positioning. To add these libraries to the Sailfish OS project it have to add the dependencies to the project YAML-file by editing the file after going through the all wizard pages.

So, we have to implement our own "Summary" page to use it inside our `wizard.json` file. And for inherit the `JsonSummaryPage` class we add the `PROJECTEXPLORER_EXPORT` macros to the class declaration.

More conversation inside PR about implementation of the QML-file wizard: https://github.com/sailfishos/sailfish-qtcreator/pull/260#discussion_r382553827.