### PR TITLE
Disable "Save All" when there are no documents to be saved

### DIFF
--- a/src/plugins/coreplugin/documentmanager.cpp
+++ b/src/plugins/coreplugin/documentmanager.cpp
@@ -30,6 +30,9 @@
 #include "idocumentfactory.h"
 #include "coreconstants.h"
 
+#include <coreplugin/actionmanager/actioncontainer.h>
+#include <coreplugin/actionmanager/actionmanager.h>
+#include <coreplugin/actionmanager/command.h>
 #include <coreplugin/diffservice.h>
 #include <coreplugin/dialogs/filepropertiesdialog.h>
 #include <coreplugin/dialogs/readonlyfilesdialog.h>
@@ -146,6 +149,8 @@ public:
     void checkOnNextFocusChange();
     void onApplicationFocusChange();
 
+    void registerSaveAllAction();
+
     QMap<QString, FileState> m_states; // filePathKey -> FileState
     QSet<QString> m_changedFiles; // watched file paths collected from file watcher notifications
     QList<IDocument *> m_documentsWithoutWatch;
@@ -170,6 +175,8 @@ public:
     // signal
     // That makes the code easier
     IDocument *m_blockedIDocument = nullptr;
+
+    QAction *m_saveAllAction;
 };
 
 static DocumentManager *m_instance;
@@ -213,7 +220,20 @@ void DocumentManagerPrivate::onApplicationFocusChange()
     m_instance->checkForReload();
 }
 
-DocumentManagerPrivate::DocumentManagerPrivate()
+void DocumentManagerPrivate::registerSaveAllAction()
+{
+    ActionContainer *mfile = ActionManager::actionContainer(Constants::M_FILE);
+    Command *cmd = ActionManager::registerAction(m_saveAllAction, Constants::SAVEALL);
+    cmd->setDefaultKeySequence(QKeySequence(useMacShortcuts ? QString() : tr("Ctrl+Shift+S")));
+    mfile->addAction(cmd, Constants::G_FILE_SAVE);
+    m_saveAllAction->setEnabled(false);
+    connect(m_saveAllAction, &QAction::triggered, []() {
+        DocumentManager::saveAllModifiedDocumentsSilently();
+    });
+}
+
+DocumentManagerPrivate::DocumentManagerPrivate() :
+    m_saveAllAction(new QAction(tr("Save A&ll"), this))
 {
     // we do not want to do too much directly in the focus change event, so queue the connection
     connect(qApp,
@@ -330,6 +350,7 @@ void DocumentManager::addDocuments(const QList<IDocument *> &documents, bool add
                         m_instance, &DocumentManager::documentDestroyed);
                 connect(document, &IDocument::filePathChanged,
                         m_instance, &DocumentManager::filePathChanged);
+                connect(document, &IDocument::changed, m_instance, &DocumentManager::updateSaveAll);
                 d->m_documentsWithoutWatch.append(document);
             }
         }
@@ -342,6 +363,7 @@ void DocumentManager::addDocuments(const QList<IDocument *> &documents, bool add
             connect(document, &QObject::destroyed, m_instance, &DocumentManager::documentDestroyed);
             connect(document, &IDocument::filePathChanged,
                     m_instance, &DocumentManager::filePathChanged);
+            connect(document, &IDocument::changed, m_instance, &DocumentManager::updateSaveAll);
             addFileInfo(document);
         }
     }
@@ -454,6 +476,11 @@ void DocumentManager::filePathChanged(const FileName &oldName, const FileName &n
     emit m_instance->documentRenamed(doc, oldName.toString(), newName.toString());
 }
 
+void DocumentManager::updateSaveAll()
+{
+    d->m_saveAllAction->setEnabled(!modifiedDocuments().empty());
+}
+
 /*!
     Adds an IDocument object to the collection. If \a addWatcher is \c true
     (the default),
@@ -491,6 +518,7 @@ bool DocumentManager::removeDocument(IDocument *document)
         disconnect(document, &IDocument::changed, m_instance, &DocumentManager::checkForNewFileName);
     }
     disconnect(document, &QObject::destroyed, m_instance, &DocumentManager::documentDestroyed);
+    disconnect(document, &IDocument::changed, m_instance, &DocumentManager::updateSaveAll);
     return addWatcher;
 }
 
@@ -721,6 +749,7 @@ bool DocumentManager::saveDocument(IDocument *document, const QString &fileName,
 
     addDocument(document, addWatcher);
     unexpectFileChange(effName);
+    m_instance->updateSaveAll();
     return ret;
 }
 
@@ -1473,6 +1502,11 @@ void DocumentManager::setFileDialogLastVisitedDirectory(const QString &directory
 void DocumentManager::notifyFilesChangedInternally(const QStringList &files)
 {
     emit m_instance->filesChangedInternally(files);
+}
+
+void DocumentManager::registerSaveAllAction()
+{
+    d->registerSaveAllAction();
 }
 
 // -------------- FileChangeBlocker

--- a/src/plugins/coreplugin/documentmanager.h
+++ b/src/plugins/coreplugin/documentmanager.h
@@ -162,6 +162,8 @@ private:
     void checkForReload();
     void changedFile(const QString &file);
     void filePathChanged(const Utils::FileName &oldName, const Utils::FileName &newName);
+    void updateSaveAll();
+    static void registerSaveAllAction();
 
     friend class Core::Internal::MainWindow;
     friend class Core::Internal::DocumentManagerPrivate;

--- a/src/plugins/coreplugin/mainwindow.cpp
+++ b/src/plugins/coreplugin/mainwindow.cpp
@@ -523,11 +523,7 @@ void MainWindow::registerDefaultActions()
     mfile->addAction(cmd, Constants::G_FILE_SAVE);
 
     // SaveAll Action
-    m_saveAllAction = new QAction(tr("Save A&ll"), this);
-    cmd = ActionManager::registerAction(m_saveAllAction, Constants::SAVEALL);
-    cmd->setDefaultKeySequence(QKeySequence(useMacShortcuts ? QString() : tr("Ctrl+Shift+S")));
-    mfile->addAction(cmd, Constants::G_FILE_SAVE);
-    connect(m_saveAllAction, &QAction::triggered, this, &MainWindow::saveAll);
+    DocumentManager::registerSaveAllAction();
 
     // Print Action
     icon = QIcon::fromTheme(QLatin1String("document-print"));
@@ -864,11 +860,6 @@ IDocument *MainWindow::openFiles(const QStringList &fileNames,
 void MainWindow::setFocusToEditor()
 {
     EditorManagerPrivate::doEscapeKeyFocusMoveMagic();
-}
-
-void MainWindow::saveAll()
-{
-    DocumentManager::saveAllModifiedDocumentsSilently();
 }
 
 void MainWindow::exit()

--- a/src/plugins/coreplugin/mainwindow.h
+++ b/src/plugins/coreplugin/mainwindow.h
@@ -117,7 +117,6 @@ private:
     void openFile();
     void aboutToShowRecentFiles();
     void setFocusToEditor();
-    void saveAll();
     void aboutQtCreator();
     void aboutPlugins();
     void updateFocusWidget(QWidget *old, QWidget *now);


### PR DESCRIPTION
Fixes: QTCREATORBUG-22072
Change-Id: I6c84e0004d1ada27bfcec59f509d066f1b03ca2c
Reviewed-by: Eike Ziller <eike.ziller@qt.io>