### PR TITLE
Sfdk: Remove port forwarding rule synchronously during addition

### DIFF
--- a/src/libs/sfdk/vboxvirtualmachine.cpp
+++ b/src/libs/sfdk/vboxvirtualmachine.cpp
@@ -634,7 +634,10 @@ void VBoxVirtualMachinePrivate::doAddPortForwarding(const QString &ruleName,
     Q_ASSERT(context);
     Q_ASSERT(functor);
 
-    doRemovePortForwarding(ruleName, Sdk::instance(), [](bool) {/* noop */});
+    bool ok;
+    Sfdk::execAsynchronous(std::tie(ok),
+                           std::mem_fn(&VBoxVirtualMachinePrivate::doRemovePortForwarding),
+                           this, ruleName);
 
     qCDebug(vms) << "Setting port forwarding for" << q->uri().toString() << "from"
         << hostPort << "to" << emulatorVmPort;


### PR DESCRIPTION
**Problem:** Adding the port forwarding rule is a task of the `VBoxVirtualMachinePrivate::doAddPortForwarding()` method. Actually, this method updates a port forwarding rule. It removes a port forwarding rule that already exists and adds a new one with the same name. For removing existing rules this method uses the `doRemovePortForwarding()` call that is asynchronous. Thus, we get a case when addition is done earlier than removing and in the end the `doAddPortForwarding()` removes the rule that was just added.

**Solution:** As a solution we propose to make the `doRemovePortForwarding()` call inside the `VBoxVirtualMachinePrivate::doAddPortForwarding()` method synchronous using `Sfdk::execAsynchronous()`. Thus, removing of the rule always will be performed before adding a new one.