### PR TITLE
TeaLeafReader: Don't forcefully stop CMake when restarting

### DIFF
--- a/src/plugins/cmakeprojectmanager/tealeafreader.h
+++ b/src/plugins/cmakeprojectmanager/tealeafreader.h
@@ -74,6 +74,9 @@ private:
     bool extractFlagsFromNinja(const CMakeBuildTarget &buildTarget, QHash<QString, QStringList> &cache, Core::Id lang) const;
 
     Utils::QtcProcess *m_cmakeProcess = nullptr;
+    bool m_stopping = false;
+    bool m_cmakeQueue = false;
+    QStringList m_queuedArguments;
 
     // For error reporting:
     ProjectExplorer::IOutputParser *m_parser = nullptr;


### PR DESCRIPTION
Trying forcefully stop cmake is not a good idea with merssh, for two reasons:
1) It doesn't work, cmake keeps on running on the build engine
2) It kills merssh, which results in cmake files not having their paths mapped.
Therefore, it's better to just let cmake run to finish, ignore the results, and start again.

This might not be perfect solution, but it's going to be a temporary one anyway: upstream is getting rid of the whole TeaLeafReader in 4.13. This probably means that we are going to have to figure out how to run cmake in server mode inside build targets, translating paths on the fly...