### PR TITLE
Jb50389 fix

### DIFF
--- a/src/tools/sfdk/sdkmanager.cpp
+++ b/src/tools/sfdk/sdkmanager.cpp
@@ -1368,6 +1368,8 @@ bool SdkManager::mapEnginePaths(QString *program, QStringList *arguments, QStrin
     };
 
     for (const Mapping &mapping : mappings) {
+        if (mapping.hostPath.isEmpty())
+            continue;
         qCDebug(sfdk) << "Mapping" << mapping.hostPath << "as" << mapping.enginePath;
         auto mapGreedy = [=](QString string) {
             QRegularExpression::PatternOption reCaseSensitivity = mapping.cs == Qt::CaseInsensitive

--- a/src/tools/sfdk/sdkmanager.h
+++ b/src/tools/sfdk/sdkmanager.h
@@ -179,6 +179,7 @@ public:
 private:
     QString cleanSharedHome() const;
     QString cleanSharedSrc() const;
+    QString cleanSharedTarget() const;
     bool mapEnginePaths(QString *program, QStringList *arguments, QString *workingDirectory,
             QProcessEnvironment *environment) const;
     QByteArray maybeReverseMapEnginePaths(const QByteArray &commandOutput) const;


### PR DESCRIPTION
All characters were had "/" added to them when executing e.g. "sfdk engine exec"