### PR TITLE
Mer: Fix parsing rpm command output after moving to sfdk

### DIFF
--- a/src/plugins/mer/merdeploysteps.cpp
+++ b/src/plugins/mer/merdeploysteps.cpp
@@ -707,12 +707,9 @@ BuildStepConfigWidget *MerMb2RpmBuildStep::createConfigWidget()
 
 void MerMb2RpmBuildStep::stdOutput(const QString &line)
 {
-    QRegExp rexp(QLatin1String("^Wrote: (/.*RPMS.*\\.rpm)"));
+    QRegExp rexp(QLatin1String("^Wrote: (.*RPMS.*\\.rpm)"));
     if (rexp.indexIn(line) != -1) {
         QString file = rexp.cap(1);
-        //TODO First replace shared home and then shared src (error prone!)
-        file.replace(QRegExp(QString("^") + Sfdk::Constants::BUILD_ENGINE_SHARED_HOME_MOUNT_POINT), m_sharedHome);
-        file.replace(QRegExp(QString("^") + Sfdk::Constants::BUILD_ENGINE_SHARED_SRC_MOUNT_POINT), m_sharedSrc);
         m_packages.append(QDir::toNativeSeparators(file));
     }
     MerProcessStep::stdOutput(line);


### PR DESCRIPTION
sfdk takes care of reverse mapping of paths, so we should not do it
here. Also, as paths under Windows don't start with '/', we must not
use it in the regexp.