### PR TITLE
MerSsh: Fix false detection of QT_QMAKE_EXECUTABLE change

### DIFF
--- a/src/tools/merssh/command.cpp
+++ b/src/tools/merssh/command.cpp
@@ -364,7 +364,7 @@ void Command::maybeDoCMakePathMapping()
         } else if (data.contains(qt5CoreDirRe)) {
             data.append("\n");
             data.append("//No help, variable specified on the command line.\n");
-            data.append("QT_QMAKE_EXECUTABLE:FILEPATH=" + sdkToolsPath() + "/qmake");
+            data.append("QT_QMAKE_EXECUTABLE:FILEPATH=" + sdkToolsPath() + "/qmake\n");
         }
 
         data.replace("/usr/include/", sharedTargetRoot + "/usr/include/");


### PR DESCRIPTION
Without EOL at EOF qtc incorrectly reads the variable with last
character removed.

(cherry picked from commit f15d78167b4af5f73dc95b019bca8ca112eef4b8)