### PR TITLE
MiniProjectTargetSelector: include <array>

### DIFF
--- a/src/plugins/projectexplorer/miniprojecttargetselector.cpp
+++ b/src/plugins/projectexplorer/miniprojecttargetselector.cpp
@@ -63,6 +63,8 @@
 #include <QAction>
 #include <QItemDelegate>
 
+#include <array>
+
 using namespace Utils;
 
 namespace ProjectExplorer {


### PR DESCRIPTION
commit 71ad0a2270f439a9425e2d273d8c86fa7cc29256 used std::array, but
didn't add the corresponding header. When compiled with Visual Studio
2019, the header is not included from anywhere else.