### PR TITLE
Sfdk: Expect the General group to be default when reading settings

### DIFF
--- a/src/libs/sfdk/sdk.cpp
+++ b/src/libs/sfdk/sdk.cpp
@@ -49,7 +49,6 @@ namespace Sfdk {
 
 namespace {
 const char SDK_MAINTENANCE_TOOL_DATA_FILE[] = "SDKMaintenanceTool.dat";
-const char GENERAL_SETTINGS_GROUP[] = "General";
 const char VBOXMANAGE_PATH[] = "VBoxManagePath";
 const char DOCKER_PATH[] = "DockerPath";
 }
@@ -416,10 +415,8 @@ void SdkPrivate::readGeneralSettings()
 
     qCDebug(lib) << "General settings location" << settings.fileName();
 
-    settings.beginGroup(GENERAL_SETTINGS_GROUP);
     customVBoxManagePath_ = settings.value(VBOXMANAGE_PATH).toString();
     customDockerPath_ = settings.value(DOCKER_PATH).toString();
-    settings.endGroup();
 }
 
 } // namespace Sfdk


### PR DESCRIPTION
By default, QSettings reads and writes settings using the General group.
If group is set to General using beginGroup(), it uses %General instead,
which is not what we want.