### PR TITLE
MerSsh: Always use OsTypeLinux when unquoting arguments

### DIFF
--- a/src/tools/merssh/main.cpp
+++ b/src/tools/merssh/main.cpp
@@ -75,7 +75,7 @@ QStringList unquoteArguments(const QStringList &arguments)
     const bool abortOnMeta = false;
     QtcProcess::SplitError splitError;
     const QStringList result = QtcProcess::splitArgs(arguments.join(QLatin1Char(' ')),
-            HostOsInfo::hostOs(), abortOnMeta, &splitError);
+            OsTypeLinux, abortOnMeta, &splitError);
     QTC_ASSERT(splitError == QtcProcess::SplitOk, return {});
 
     return result;


### PR DESCRIPTION
The wrapper scripts use single quotation mark for quoting arguments also
in Windows. QtcProcess::splitArgs does not interpret single quotation
marks with OsTypeWindows.