### PR TITLE
Update run configuration after device change

### DIFF
--- a/src/plugins/projectexplorer/miniprojecttargetselector.cpp
+++ b/src/plugins/projectexplorer/miniprojecttargetselector.cpp
@@ -108,7 +108,7 @@ public:
             return p->displayName();
         if (const auto t = qobject_cast<Target *>(object()))
             return t->displayName();
-        return static_cast<ProjectConfiguration *>(object())->displayName();
+        return static_cast<ProjectConfiguration *>(object())->expandedDisplayName();
 
     }
     QString displayName() const
@@ -1522,7 +1522,7 @@ void MiniProjectTargetSelector::updateActionAndSummary()
                 deployConfig = dc->displayName();
 
             if (RunConfiguration *rc = target->activeRunConfiguration())
-                runConfig = rc->displayName();
+                runConfig = rc->expandedDisplayName();
 
             targetToolTipText = target->overlayIconToolTip();
             targetIcon = createCenteredIcon(target->icon(), target->overlayIcon());
@@ -1571,7 +1571,7 @@ void MiniProjectTargetSelector::updateSummary()
                                    activeTarget->activeDeployConfiguration()->displayName()));
             if (!m_listWidgets[RUN]->isVisibleTo(this) && activeTarget->activeRunConfiguration())
                 summary.append(tr("Run: <b>%1</b><br/>").arg(
-                                   activeTarget->activeRunConfiguration()->displayName()));
+                                   activeTarget->activeRunConfiguration()->expandedDisplayName()));
         } else if (startupProject->needsConfiguration()) {
             summary = tr("<style type=text/css>"
                          "a:link {color: rgb(128, 128, 255, 240);}</style>"

--- a/src/plugins/projectexplorer/projectconfiguration.cpp
+++ b/src/plugins/projectexplorer/projectconfiguration.cpp
@@ -144,3 +144,8 @@ Utils::Id ProjectExplorer::idFromMap(const QVariantMap &map)
 {
     return Utils::Id::fromSetting(map.value(QLatin1String(CONFIGURATION_ID_KEY)));
 }
+
+QString ProjectConfiguration::expandedDisplayName() const
+{
+    return m_target->macroExpander()->expand(m_displayName.value());
+}

--- a/src/plugins/projectexplorer/projectconfiguration.h
+++ b/src/plugins/projectexplorer/projectconfiguration.h
@@ -56,6 +56,7 @@ public:
     Utils::Id id() const;
 
     QString displayName() const { return m_displayName.value(); }
+    QString expandedDisplayName() const;
     bool usesDefaultDisplayName() const { return m_displayName.usesDefaultValue(); }
     void setDisplayName(const QString &name);
     void setDefaultDisplayName(const QString &name);

--- a/src/plugins/projectexplorer/projectconfigurationmodel.cpp
+++ b/src/plugins/projectexplorer/projectconfigurationmodel.cpp
@@ -116,7 +116,7 @@ QVariant ProjectConfigurationModel::data(const QModelIndex &index, int role) con
     if (role == Qt::DisplayRole) {
         const int row = index.row();
         if (row < m_projectConfigurations.size())
-            return m_projectConfigurations.at(row)->displayName();
+            return m_projectConfigurations.at(row)->expandedDisplayName();
     }
 
     return QVariant();

--- a/src/plugins/projectexplorer/runconfiguration.cpp
+++ b/src/plugins/projectexplorer/runconfiguration.cpp
@@ -429,10 +429,10 @@ QString RunConfigurationFactory::decoratedTargetName(const QString &targetName, 
         if (IDevice::ConstPtr dev = DeviceKitAspect::device(target->kit())) {
             if (displayName.isEmpty()) {
                 //: Shown in Run configuration if no executable is given, %1 is device name
-                displayName = RunConfiguration::tr("Run on %1").arg(dev->displayName());
+                displayName = RunConfiguration::tr("Run on %{Device:Name}");
             } else {
                 //: Shown in Run configuration, Add menu: "name of runnable (on device name)"
-                displayName = RunConfiguration::tr("%1 (on %2)").arg(displayName, dev->displayName());
+                displayName = RunConfiguration::tr("%1 (on %{Device:Name})").arg(displayName);
             }
         }
     }

--- a/src/plugins/projectexplorer/runcontrol.cpp
+++ b/src/plugins/projectexplorer/runcontrol.cpp
@@ -361,7 +361,7 @@ void RunControl::setRunConfiguration(RunConfiguration *runConfig)
     d->runConfiguration = runConfig;
     d->runConfigId = runConfig->id();
     d->runnable = runConfig->runnable();
-    d->displayName = runConfig->displayName();
+    d->displayName = runConfig->expandedDisplayName();
     d->macroExpander = runConfig->macroExpander();
     d->buildKey = runConfig->buildKey();
     d->settingsData = runConfig->aspectData();


### PR DESCRIPTION
The run configuration name defaults to "<executable> (on <device>)".
When another device is selected e.g. using the MiniProjectTargetSelector
or Kits->Device option, the <device> part in run configuration name is
not updated and keeps referring to the initially selected device.

Change-Id: Idda828b7f33b754d3b50268d7417c9a2790db30e
Reviewed-by: Christian Kandeler <christian.kandeler@qt.io>
(cherry picked from commit 4d1b7d4c3ded97bd4480532075c310ce09111d6f)