### PR TITLE
Mer: Disable and hide RunSystemFunction on project config

### DIFF
--- a/src/plugins/mer/merqmakebuildconfiguration.cpp
+++ b/src/plugins/mer/merqmakebuildconfiguration.cpp
@@ -110,6 +110,8 @@ MerQmakeBuildConfiguration::MerQmakeBuildConfiguration(Target *target, Utils::Id
 
         maybeUpdateExtraParserArguments();
     });
+
+    disableQmakeSystem();
 }
 
 void MerQmakeBuildConfiguration::doInitialize(const ProjectExplorer::BuildInfo &info)
@@ -301,10 +303,20 @@ void MerQmakeBuildConfiguration::updateExtraParserArguments()
     qs->setRecursive(true);
 }
 
+void MerQmakeBuildConfiguration::disableQmakeSystem()
+{
+    TriStateAspect *runSystemAspect = qobject_cast<TriStateAspect *>(Utils::findOrDefault(aspects(),
+                    Utils::equal(&BaseAspect::settingsKey, QString("RunSystemFunction"))));
+    QTC_ASSERT(runSystemAspect, return);
+    runSystemAspect->setSetting(TriState::Disabled);
+    runSystemAspect->setVisible(false);
+}
+
 bool MerQmakeBuildConfiguration::fromMap(const QVariantMap &map)
 {
     if (!QmakeBuildConfiguration::fromMap(map))
         return false;
+    disableQmakeSystem();
     return true;
 }
 

--- a/src/plugins/mer/merqmakebuildconfiguration.h
+++ b/src/plugins/mer/merqmakebuildconfiguration.h
@@ -55,6 +55,7 @@ private:
     void setupExtraParserArguments();
     void maybeUpdateExtraParserArguments(bool now = false);
     void updateExtraParserArguments();
+    void disableQmakeSystem();
 
 private:
     QBasicTimer m_maybeUpdateExtraParserArgumentsTimer;


### PR DESCRIPTION
QMake should never be run on the host, so we don't want the user to
accidentally enable this