### PR TITLE
Workarounded podman support

### DIFF
--- a/src/libs/sfdk/dockervirtualmachine.cpp
+++ b/src/libs/sfdk/dockervirtualmachine.cpp
@@ -491,7 +491,9 @@ QStringList DockerVirtualMachinePrivate::listedImages(const QString &output)
 {
     QStringList images;
     const QStringList lines = output.split(QRegularExpression("[\r\n]"), Qt::SkipEmptyParts);
-    for (const QString &line : lines) {
+    for (QString line : lines) {
+        if (line.startsWith("localhost/"))
+            line = line.right(line.size() - 10);
         if (line != "<none>")
             images.append(line);
     }


### PR DESCRIPTION
This is a simple workaround to support podman.
For local images, podman always prepend "localhost".
This messes up with the sfdk engine detection that
assume image name == container name.

This workaround simply removes the prefix "localhost/"
from the image name (if found).