### PR TITLE
omp-jb53964

### DIFF
--- a/src/plugins/mer/mercmakebuildconfiguration.cpp
+++ b/src/plugins/mer/mercmakebuildconfiguration.cpp
@@ -60,8 +60,13 @@ MerCMakeBuildConfiguration::MerCMakeBuildConfiguration(Target *target, Utils::Id
     connect(aspect, &BaseAspect::changed,
             this, &BuildConfiguration::updateCacheAndEmitEnvironmentChanged);
 
+    /*
+     * We want to be sure that BE is running before parsing starts.
+     * We should not start BE while parsing is in progress using AutoConnection - it lead to crash during kit disable.
+     * Instead we start BE on parsingStarted signal using QueuedConnection.
+     */
     connect(target, &Target::parsingStarted,
-            this, &MerCMakeBuildConfiguration::ensureBuildEngineRuns);
+            this, &MerCMakeBuildConfiguration::ensureBuildEngineRuns, Qt::QueuedConnection);
 }
 
 void MerCMakeBuildConfiguration::doInitialize(const ProjectExplorer::BuildInfo &info)

--- a/src/plugins/mer/merdeployconfiguration.cpp
+++ b/src/plugins/mer/merdeployconfiguration.cpp
@@ -158,6 +158,7 @@ void MerAddRemoveSpecialDeployStepsProjectListener::timerEvent(QTimerEvent *even
 {
     if (event->timerId() == m_updateTargetsTimer.timerId()) {
         m_updateTargetsTimer.stop();
+        m_updateTargetsQueue.removeAll(nullptr);
         while (!m_updateTargetsQueue.isEmpty())
             updateTarget(m_updateTargetsQueue.dequeue());
     } else {

--- a/src/plugins/mer/merdeployconfiguration.h
+++ b/src/plugins/mer/merdeployconfiguration.h
@@ -122,7 +122,7 @@ private:
     static void removeStep(ProjectExplorer::BuildStepList *stepList, Utils::Id stepId);
 
 private:
-    QQueue<ProjectExplorer::Target *> m_updateTargetsQueue;
+    QQueue<QPointer<ProjectExplorer::Target>> m_updateTargetsQueue;
     QBasicTimer m_updateTargetsTimer;
 };
 


### PR DESCRIPTION
Connect to [ensureBuildEngineRuns](https://github.com/sailfishos/sailfish-qtcreator/blob/79f4c099604e6272716cf9f9b04c76e7c48dea81/src/plugins/mer/mercmakebuildconfiguration.cpp#L64) using AutoConnection will start nested event loop inside main event loop.
That may break code execution inside [CMakeBuildSystem::triggerParsing](https://github.com/sailfishos/sailfish-qtcreator/blob/d93aaa2d00e5bf43f3d42f9f410dc79a969fb6a7/src/plugins/cmakeprojectmanager/cmakebuildsystem.cpp#L215) if user choose to [disable current kit.](https://github.com/sailfishos/sailfish-qtcreator/blob/d93aaa2d00e5bf43f3d42f9f410dc79a969fb6a7/src/plugins/projectexplorer/targetsettingspanel.cpp#L444)
The kit will be deleted inside nested event loop, then code execution return to [CMakeBuildSystem::triggerParsing.](https://github.com/sailfishos/sailfish-qtcreator/blob/d93aaa2d00e5bf43f3d42f9f410dc79a969fb6a7/src/plugins/cmakeprojectmanager/cmakebuildsystem.cpp#L215)
This will lead to dangling pointers (for example inside [projectDirectory](https://github.com/sailfishos/sailfish-qtcreator/blob/d93aaa2d00e5bf43f3d42f9f410dc79a969fb6a7/src/plugins/cmakeprojectmanager/cmakebuildsystem.cpp#L258) call) and eventually QtC will crash.
Using QueuedConnection in the contrary prevents breaking code execution and therefore should solve the problem.