### PR TITLE
Sfdk: enqueue checkpoint in VirtualMachinePrivate::doInitGuest()

### DIFF
--- a/src/libs/sfdk/virtualmachine.cpp
+++ b/src/libs/sfdk/virtualmachine.cpp
@@ -815,7 +815,7 @@ void VirtualMachinePrivate::setReservedPortListForwarding(ReservedPortList which
 
 void VirtualMachinePrivate::doInitGuest()
 {
-    // noop
+    BatchComposer::enqueueCheckPoint(this, [](){});
 }
 
 void VirtualMachinePrivate::enableUpdates()


### PR DESCRIPTION
The UI is waiting for the done signals from initGuest, so we need to do
something, even when we are doing nothing.