### PR TITLE
Sfdk: Move checkpoint enqueuing from VirtualMachinePrivate

### DIFF
--- a/src/libs/sfdk/virtualmachine.cpp
+++ b/src/libs/sfdk/virtualmachine.cpp
@@ -815,7 +815,7 @@ void VirtualMachinePrivate::setReservedPortListForwarding(ReservedPortList which
 
 void VirtualMachinePrivate::doInitGuest()
 {
-    BatchComposer::enqueueCheckPoint(this, [](){});
+    // noop
 }
 
 void VirtualMachinePrivate::enableUpdates()

--- a/src/libs/sfdk/vmconnection.cpp
+++ b/src/libs/sfdk/vmconnection.cpp
@@ -1082,6 +1082,7 @@ bool VmConnection::sshStmStep()
             BatchComposer composer = BatchComposer::createBatch("VmConnection::initGuest");
             m_guestInitBatch = composer.batch();
             emit initGuest();
+            BatchComposer::enqueueCheckPoint(this, [](){});
             // Errors not considered fatal here
             connect(m_guestInitBatch.data(), &CommandRunner::done,
                     this, &VmConnection::onGuestInitFinished);


### PR DESCRIPTION
...to VmConnection, where the BatchComposer is instantiated.