### PR TITLE
Sfdk: fix warning message when compile_commands.json is unsupported

### DIFF
--- a/share/qtcreator/sfdk/modules/70-ide-compiledb/script.mjs
+++ b/share/qtcreator/sfdk/modules/70-ide-compiledb/script.mjs
@@ -20,7 +20,7 @@ export function mapCompilationDatabasePaths() {
             if (object.command) {
                 if (!warnedAboutCommandField) {
                     console.warn(qsTr("%1: The \"command\" field is not supported - unit(s) excluded")
-                            .qsTr(compilationDb));
+                            .arg(compilationDb));
                     warnedAboutCommandField = true;
                 }
                 return acc;


### PR DESCRIPTION
Signed-off-by: Nicolas Werner <nicolas.werner@hotmail.de>