### PR TITLE
Sfdk: Set GUI/LastNormalWindowPosition on setVideoMode

### DIFF
--- a/src/libs/sfdk/vboxvirtualmachine.cpp
+++ b/src/libs/sfdk/vboxvirtualmachine.cpp
@@ -523,7 +523,6 @@ void VBoxVirtualMachinePrivate::doSetStorageSizeMb(int storageSizeMb, const QObj
     qCDebug(vms) << "Changing storage size of" << q->uri().toString() << "to" << storageSizeMb << "MB";
 
     BatchComposer composer = BatchComposer::createBatch("VBoxVirtualMachinePrivate::doSetStorageSizeMb");
-    composer.batch()->setPropagateFailure(true);
 
     const QPointer<const QObject> context_{context};
     fetchInfo(VirtualMachineInfo::StorageInfo, Sdk::instance(),

--- a/src/libs/sfdk/vboxvirtualmachine.cpp
+++ b/src/libs/sfdk/vboxvirtualmachine.cpp
@@ -414,7 +414,6 @@ void VBoxVirtualMachinePrivate::setVideoMode(const QSize &size, int depth,
         << "depth" << depth;
 
     BatchComposer composer = BatchComposer::createBatch("VBoxVirtualMachinePrivate::setVideoMode");
-    composer.batch()->setPropagateFailure(true);
 
     QString videoMode = QStringLiteral("%1x%2x%3")
         .arg(size.width())


### PR DESCRIPTION
VirtualBox 7.0 no longer uses GUI/LastGuestSizeHint, so we need to set both in order to make sure window size is correct